### PR TITLE
Adding ability to format range of file

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -18,6 +18,7 @@
     main/1,
     init/1,
     format_file/2,
+    format_range/3,
     read_forms/1,
     read_forms_string/2,
     format_error/1,
@@ -32,7 +33,11 @@
 
 -define(PAGE_WIDTH, 92).
 
--define(SCAN_START, {1, 1}).
+-define(FIRST_LINE, 1).
+
+-define(FIRST_COLUMN, 1).
+
+-define(SCAN_START, {?FIRST_LINE, ?FIRST_COLUMN}).
 
 -define(SCAN_OPTS, [text, return_comments]).
 
@@ -69,6 +74,30 @@ format_file(FileName, Out) ->
         {error, Error} -> {error, Error}
     end.
 
+-spec format_range(
+    file:name_all(),
+    erlfmt_scan:location(),
+    erlfmt_scan:location()
+) ->
+    {ok, string(), [error_info()]} |
+    {error, error_info()} |
+    {options, [{erlfmt_scan:location(), erlfmt_scan:location()}]}.
+format_range(FileName, StartLocation, EndLocation) ->
+   try
+        {ok, Forms, Warnings} = file_read_forms(FileName),
+        case verify_ranges(Forms, StartLocation, EndLocation) of
+            ok ->
+                InRange = forms_in_range(Forms, StartLocation, EndLocation),
+                [$\n | Result] = format_forms(InRange),
+                verify_forms(FileName, InRange, Result),
+                {ok, unicode:characters_to_binary(Result), Warnings};
+            {options, Options} ->
+                {options, Options}
+        end
+    catch
+        {error, Error} -> {error, Error}
+    end.
+
 %% API entry point
 -spec read_forms(file:name_all()) ->
     {ok, [erlfmt_parse:abstract_form()], [error_info()]} | {error, error_info()}.
@@ -79,9 +108,14 @@ read_forms(FileName) ->
     end.
 
 file_read_forms(FileName) ->
+    read_file(FileName, fun (File) ->
+        read_forms(erlfmt_scan:io_form(File), FileName, [], [])
+    end).
+
+read_file(FileName, Action) ->
     case file:open(FileName, [read, {encoding, utf8}]) of
         {ok, File} ->
-            try read_forms(erlfmt_scan:io_form(File), FileName, [], [])
+            try Action(File)
             after file:close(File)
             end;
         {error, Reason} ->
@@ -117,7 +151,8 @@ parse_form(Tokens, Comments, FileName, Cont, Warnings) ->
     end.
 
 form_string(Cont) ->
-    {raw_string, string:trim(erlfmt_scan:last_form_string(Cont), both, "\n")}.
+    {String, Anno} = erlfmt_scan:last_form_string(Cont),
+    {raw_string, Anno, string:trim(String, both, "\n")}.
 
 format_forms([{attribute, _, {atom, _, spec}, _} = Attr, {function, _, _} = Fun | Rest]) ->
     [$\n, format_form(Attr), format_form(Fun) | format_forms(Rest)];
@@ -126,7 +161,7 @@ format_forms([Form | Rest]) ->
 format_forms([]) ->
     [].
 
-format_form({raw_string, String}) ->
+format_form({raw_string, _Anno, String}) ->
     [String, $\n];
 format_form(Form) ->
     Doc = erlfmt_format:form_to_algebra(Form),
@@ -150,7 +185,7 @@ verify_forms(FileName, Forms, Formatted) ->
 
 equivalent(Element, Element) ->
     true;
-equivalent({raw_string, RawL}, {raw_string, RawR}) ->
+equivalent({raw_string, _AnnoL, RawL}, {raw_string, _AnnoR, RawR}) ->
     string:equal(RawL, RawR) orelse throw({not_equivalent, RawL, RawR});
 equivalent({Type, _}, {Type, _}) ->
     true;
@@ -220,3 +255,51 @@ format_error({not_equivalent, Node1, Node2}) ->
     );
 format_error(could_not_reparse) ->
     "formatter result invalid, could not reparse".
+
+verify_ranges(Forms, StartLocation, EndLocation) ->
+    case possible_ranges(Forms, StartLocation, EndLocation) of
+        [{StartLocation, EndLocation}] ->
+            ok;
+        Options ->
+            {options, Options}
+    end.
+
+possible_ranges(Forms, StartLocation, EndLocation) ->
+    case forms_in_range(Forms, StartLocation, EndLocation) of
+        [] ->
+            [];
+        [OnlyForm] ->
+            [get_location_range(OnlyForm)];
+        MultipleForms ->
+            combine(
+                get_possible_locations(MultipleForms, StartLocation, fun get_location/1),
+                get_possible_locations(lists:reverse(MultipleForms), EndLocation, fun get_end_location/1))
+    end.
+
+forms_in_range(Forms, StartLocation, EndLocation) ->
+    [Form || Form <- Forms, form_intersects_range(Form, StartLocation, EndLocation)].
+
+form_intersects_range(Form, StartLocation, EndLocation) ->
+    {Start, End} = get_location_range(Form),
+    ((Start < StartLocation) and (End >= StartLocation)) or
+    ((Start >= StartLocation) and (Start =< EndLocation)).
+
+get_possible_locations([Option1, Option2 | _], Location, GetLoc) ->
+    case GetLoc(Option1) of
+        Location ->
+            [Location];
+        OptionalLocation ->
+            [OptionalLocation, GetLoc(Option2)]
+    end.
+
+combine(L1, L2) ->
+    [{X1, X2} || X1 <- L1, X2 <- L2].
+
+get_location_range(Form) ->
+    {get_location(Form), get_end_location(Form)}.
+
+get_location(Form) ->
+    erlfmt_scan:get_anno(location, Form).
+
+get_end_location(Form) ->
+    erlfmt_scan:get_anno(end_location, Form).

--- a/src/erlfmt_scan.erl
+++ b/src/erlfmt_scan.erl
@@ -140,7 +140,7 @@ erl_scan_tokens(String, Loc) ->
 eof(undefined, Loc) ->
     {{eof, Loc}, undefined}.
 
--spec last_form_string(state()) -> {unicode:chardata(), erl_anno:anno()}.
+-spec last_form_string(state()) -> {unicode:chardata(), anno()}.
 last_form_string(#state{original = Tokens}) ->
     stringify_tokens(Tokens).
 

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -50,7 +50,10 @@
     smoke_test_cli/1,
     snapshot_simple_comments/1,
     snapshot_comments/1,
-    snapshot_broken/1
+    snapshot_broken/1,
+    simple_comments_range/1,
+    comments_range/1,
+    broken_range/1
 ]).
 
 suite() ->
@@ -100,13 +103,18 @@ groups() ->
             snapshot_simple_comments,
             snapshot_comments,
             snapshot_broken
+        ]},
+        {range_tests, [parallel], [
+            simple_comments_range,
+            comments_range,
+            broken_range
         ]}
     ].
 
 group(_) -> [].
 
 all() ->
-    [{group, smoke_tests}, {group, parser}].
+    [{group, smoke_tests}, {group, parser}, {group, range_tests}].
 
 %%--------------------------------------------------------------------
 %% TEST CASES
@@ -875,3 +883,25 @@ snapshot_formatted(Module, Config) ->
     {ok, FormattedFormatted} =
         file:read_file(filename:join([PrivDir, Module ++ ".formatted"])),
     ?assertEqual(Expected, FormattedFormatted).
+
+simple_comments_range(Config) ->
+    format_range(Config, "simple_comments.erl").
+
+comments_range(Config) ->
+    format_range(Config, "simple_comments.erl").
+
+broken_range(Config) ->
+    format_range(Config, "broken.erl").
+
+format_range(Config, File) ->
+    DataDir = ?config(data_dir, Config),
+    Path = DataDir++File,
+    case erlfmt:format_range(Path, {3,45}, {47,1}) of
+        {ok, _Output, _} -> ok;
+        {options, Options} -> range_format_exact(Options, Path)
+    end.
+
+range_format_exact([], _Path) -> ok;
+range_format_exact([{Start,End}|Options], Path) ->
+    {ok, _Output, _} = erlfmt:format_range(Path, Start, End),
+    range_format_exact(Options, Path).


### PR DESCRIPTION
Adding the ability to format a specific range of a file. In this iteration
 the function will either return a formatted string for the
  area that is being reformatted, or a list of alternate ranges
  which are ok, i.e. contains one or more forms.

In order to do this I'm also adding location annotations to raw_string in order to tell if the raw string is in the range that is being formatted.