### PR TITLE
Process all files from command arguments

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -44,8 +44,10 @@ main(Argv) ->
     application:ensure_all_started(erlfmt),
     Opts = erlfmt_cli:opts(),
     case getopt:parse(Opts, Argv) of
-        {ok, {ArgOpts, _Extra}} ->
+        {ok, {ArgOpts, []}} ->
             erlfmt_cli:do(ArgOpts, "erlfmt");
+        {ok, {ArgOpts, ExtraFiles}} ->
+            erlfmt_cli:do([{files, ExtraFiles} | ArgOpts], "erlfmt");
         {error, Error} ->
             io:put_chars(standard_error, [getopt:format_error(Opts, Error), "\n\n"]),
             getopt:usage(Opts, "erlfmt")

--- a/src/rebar3_fmt_prv.erl
+++ b/src/rebar3_fmt_prv.erl
@@ -37,9 +37,13 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()}.
 do(State) ->
-    {ArgOpts, _Extra} = rebar_state:command_parsed_args(State),
     ConfigOpts = rebar_state:get(State, erlfmt, []),
-    erlfmt_cli:do(ConfigOpts ++ ArgOpts, "rebar3 fmt"),
+    case rebar_state:command_parsed_args(State) of
+        {ArgOpts, []} ->
+            erlfmt_cli:do(ConfigOpts ++ ArgOpts, "rebar3 fmt");
+        {ArgOpts, ExtraFiles} ->
+            erlfmt_cli:do(ConfigOpts ++ [{files, ExtraFiles}] ++ ArgOpts, "rebar3 fmt")
+    end,
     {ok, State}.
 
 format_error(Reason) ->


### PR DESCRIPTION
I assumed getopt would return all plain arguments as multiple `{file, _}`
tuples, I was wrong - they are returned as the "extra options" and only
the first file is properly processed. This handles it correctly.

Tested manually both escript and plugin, we currently don't have a setup
for testing CLI.