### PR TITLE
Fix formatting overlong lines

### DIFF
--- a/src/erlfmt_algebra.erl
+++ b/src/erlfmt_algebra.erl
@@ -374,10 +374,12 @@ reject_invalid(Layouts, MaxWidth, Options) ->
 best_unfit([]) -> [];
 best_unfit([First | Rest]) -> [best_unfit(Rest, First)].
 
-best_unfit([{CandidateMetric, _} = Candidate | Rest], {BestMetric, _})
-        when CandidateMetric#metric.max_width < BestMetric#metric.max_width ->
-    best_unfit(Rest, Candidate);
-best_unfit([_Candidate | Rest], Best) ->
-    best_unfit(Rest, Best);
+best_unfit([{CandidateMetric, _} = Candidate | Rest], {BestMetric, _} = Best) ->
+    case (CandidateMetric#metric.max_width < BestMetric#metric.max_width) orelse
+             (CandidateMetric#metric.max_width =:= BestMetric#metric.max_width andalso
+                 CandidateMetric < BestMetric) of
+        true -> best_unfit(Rest, Candidate);
+        false -> best_unfit(Rest, Best)
+    end;
 best_unfit([], Best) ->
     Best.

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -51,6 +51,7 @@
     snapshot_simple_comments/1,
     snapshot_comments/1,
     snapshot_broken/1,
+    snapshot_overlong/1,
     simple_comments_range/1,
     comments_range/1,
     broken_range/1
@@ -102,7 +103,8 @@ groups() ->
         {snapshot_tests, [parallel], [
             snapshot_simple_comments,
             snapshot_comments,
-            snapshot_broken
+            snapshot_broken,
+            snapshot_overlong
         ]},
         {range_tests, [parallel], [
             simple_comments_range,
@@ -860,6 +862,8 @@ snapshot_simple_comments(Config) -> snapshot_same("simple_comments.erl", Config)
 snapshot_comments(Config) -> snapshot_formatted("comments.erl", Config).
 
 snapshot_broken(Config) -> snapshot_formatted("broken.erl", Config).
+
+snapshot_overlong(Config) -> snapshot_formatted("overlong.erl", Config).
 
 snapshot_same(Module, Config) ->
     DataDir = ?config(data_dir, Config),

--- a/test/erlfmt_SUITE_data/overlong.erl
+++ b/test/erlfmt_SUITE_data/overlong.erl
@@ -1,0 +1,10 @@
+-module(overlong).
+
+-export([process/6]).
+
+process(_Arg1, Arg2, _Arg3, _Arg4, _Arg5, _Arg6) ->
+    % Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut ultricies magna. Donec sagittis vulputate tempus.
+    % Curabitur nisi metus.
+    other_module:call('some.atom'),
+    other_module:call(with_many, extremely_long_arguments, that_should, be_broken_up, size(Arg2)),
+    ok.

--- a/test/erlfmt_SUITE_data/overlong.erl.formatted
+++ b/test/erlfmt_SUITE_data/overlong.erl.formatted
@@ -1,0 +1,16 @@
+-module(overlong).
+
+-export([process/6]).
+
+process(_Arg1, Arg2, _Arg3, _Arg4, _Arg5, _Arg6) ->
+    % Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut ultricies magna. Donec sagittis vulputate tempus.
+    % Curabitur nisi metus.
+    other_module:call('some.atom'),
+    other_module:call(
+        with_many,
+        extremely_long_arguments,
+        that_should,
+        be_broken_up,
+        size(Arg2)
+    ),
+    ok.


### PR DESCRIPTION
Summary:
This improves formatting of situations where there are lines that cannot
be shortened - like a very long comment. This is achieved by having a
smarter "best_unfit" function in the algorithm.