### PR TITLE
Remove warning about # when formatting escript

### DIFF
--- a/test/erlfmt_escript_SUITE.erl
+++ b/test/erlfmt_escript_SUITE.erl
@@ -1,0 +1,32 @@
+-module(erlfmt_escript_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% Test server callbacks
+-export([all/0]).
+
+%% Test cases
+-export([hello/1, hello_sh/1]).
+
+%% Test server callbacks
+all() -> [hello, hello_sh].
+
+%% Test cases
+hello(Config) ->
+    DataDir = ?config(data_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    File = "hello",
+    {ok, []} = erlfmt:format_file(filename:join(DataDir, File), {ignore, {path, PrivDir}}),
+    {ok, Expected} = file:read_file(filename:join(DataDir, File ++ ".formatted")),
+    {ok, Expected} = file:read_file(filename:join(PrivDir, File)).
+
+hello_sh(Config) ->
+    DataDir = ?config(data_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    File = "hello_sh",
+    Path = filename:join(DataDir, File),
+    {ok, [Warning]} = erlfmt:format_file(Path, {ignore, {path, PrivDir}}),
+    {Path, #{end_location := {1, 2}, location := {1, 1}},
+        erlfmt_parse, ["syntax error before: ", "'#'"]} = Warning,
+    {ok, Expected} = file:read_file(filename:join(DataDir, File ++ ".formatted")),
+    {ok, Expected} = file:read_file(filename:join(PrivDir, File)).

--- a/test/erlfmt_escript_SUITE_data/hello
+++ b/test/erlfmt_escript_SUITE_data/hello
@@ -1,0 +1,3 @@
+#! /usr/bin/env escript
+
+main( _ ) -> io:fwrite( "hello world\n" ).

--- a/test/erlfmt_escript_SUITE_data/hello.formatted
+++ b/test/erlfmt_escript_SUITE_data/hello.formatted
@@ -1,0 +1,3 @@
+#! /usr/bin/env escript
+
+main( _ ) -> io:fwrite( "hello world\n" ).

--- a/test/erlfmt_escript_SUITE_data/hello_sh
+++ b/test/erlfmt_escript_SUITE_data/hello_sh
@@ -1,0 +1,2 @@
+#! /bin/sh
+echo hello world

--- a/test/erlfmt_escript_SUITE_data/hello_sh.formatted
+++ b/test/erlfmt_escript_SUITE_data/hello_sh.formatted
@@ -1,0 +1,2 @@
+#! /bin/sh
+echo hello world


### PR DESCRIPTION
The check for removing the warning can be considered as too much/brittle. Maybe it is not necessary to check for ''escript'', and instead always remove the warning about # first in the file.

As can be seen in the escript that is formatted, it is worth investigating why the first line formatted is not correctly formatted. It is still
main( [_] ) ->
after formatting.
Current erlfmt will remove those extra spaces, except when formatting escript.
This is not due to this change.

Finally, I have not formatted erlfmt.erl with erlfmt. That creates a lot of changes in code that I have not touched.