### PR TITLE
erlfmt_format: make list and binary comprehensions "next break fits"

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -47,7 +47,7 @@
 
 -define(INDENT, 4).
 
--define(NEXT_BREAK_FITS, [map, list, record, block, 'fun']).
+-define(NEXT_BREAK_FITS, [map, list, record, block, 'fun', lc, bc]).
 
 -define(NEXT_BREAK_FITS_OPS, ['=', '::']).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -941,6 +941,13 @@ list_comprehension(Config) when is_list(Config) ->
         "       X < 10\n"
         "]",
         25
+    ),
+    ?assertFormat(
+        "lists:unzip([{ALong, B}|| ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)])",
+        "lists:unzip([\n"
+        "    {ALong, B}\n"
+        "    || ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)\n"
+        "])"
     ).
 
 binary_comprehension(Config) when is_list(Config) ->
@@ -972,6 +979,13 @@ binary_comprehension(Config) when is_list(Config) ->
         "       X < 10\n"
         ">>",
         25
+    ),
+    ?assertFormat(
+        "lists:unzip(<<<<ALong, B>>|| ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)>>)",
+        "lists:unzip(<<\n"
+        "    <<ALong, B>>\n"
+        "    || ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)\n"
+        ">>)"
     ).
 
 call(Config) when is_list(Config) ->


### PR DESCRIPTION
Fixes #25 