### PR TITLE
fix licenses and format

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -271,7 +271,10 @@ string_concat_equivalent(String, Values) ->
     string:equal(String, [Value || {string, _, Value} <- Values]).
 
 concat_equivalent(ValuesL, ValuesR) ->
-    string:equal([Value || {string, _, Value} <- ValuesL], [Value || {string, _, Value} <- ValuesR]).
+    string:equal([Value || {string, _, Value} <- ValuesL], [
+        Value
+        || {string, _, Value} <- ValuesR
+    ]).
 
 equivalent_list([L | Ls], [R | Rs]) ->
     equivalent(L, R) andalso equivalent_list(Ls, Rs);

--- a/src/erlfmt_algebra.erl
+++ b/src/erlfmt_algebra.erl
@@ -1,3 +1,18 @@
+%% Copyright (c) 2012-2020 Plataformatec
+%% Copyright (c) Facebook, Inc. and its affiliates.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 %   A set of functions for creating and manipulating algebra
 %   documents.
 

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -62,7 +62,7 @@ insert_expr_list([Expr0 | Exprs], Comments0, Acc) when is_tuple(Expr0) ->
 insert_expr_list([], Comments, Acc) ->
     {lists:reverse(Acc), Comments}.
 
-insert_expr_container(Exprs, []) -> 
+insert_expr_container(Exprs, []) ->
     Exprs;
 insert_expr_container([Expr0 | Exprs], Comments0) when is_tuple(Expr0) ->
     {Expr, Comments} = insert_expr(Expr0, Comments0),

--- a/test/erlfmt_algebra_SUITE.erl
+++ b/test/erlfmt_algebra_SUITE.erl
@@ -1,3 +1,4 @@
+%% Copyright (c) 2012-2020 Plataformatec
 %% Copyright (c) Facebook, Inc. and its affiliates.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Add Facebook license to algebra and include Elixir copyright `Copyright (c) 2012-2020 Plataformatec` for algebra files.