### PR TITLE
Concat converted from a string also forces breaks

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -236,7 +236,7 @@ string_to_algebra(Text) ->
         [First | Lines] ->
             FirstD = string([First | "\\n\""]),
             LinesD = string_lines_to_algebra(Lines),
-            line(FirstD, LinesD)
+            concat([force_breaks(), FirstD, line(), LinesD])
     end.
 
 string_lines_to_algebra([LastLine]) ->

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -247,6 +247,13 @@ string_concat(Config) when is_list(Config) ->
         "    \"A\\n\"\n"
         "    \"B\"\n"
         "    \"C\"."
+    ),
+    ?assertFormat(
+        "X = \"foo\n"
+        "bar\"",
+        "X =\n"
+        "    \"foo\\n\"\n"
+        "    \"bar\""
     ).
 
 unary_operator(Config) when is_list(Config) ->


### PR DESCRIPTION
This is a follow-up to https://github.com/WhatsApp/erlfmt/commit/46eda2c639ef61eb245df0f54c739aed4f910e05 where we omitted this case.