### PR TITLE
erlfmt_format: make position of return type in specs consistent

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -527,8 +527,13 @@ clause_to_algebra({clause, Meta, Head, Guards, Body}) ->
         group(concat(Nested(GuardsD), break(<<" ">>), <<"->">>)),
         Nested(BodyD)
     );
-clause_to_algebra({spec_clause, Meta, Head, Body, empty}) ->
-    clause_to_algebra({clause, Meta, Head, empty, Body});
+clause_to_algebra({spec_clause, _Meta, Head, [Body], empty}) ->
+    HeadD = expr_to_algebra(Head),
+    BodyD = expr_to_algebra(Body),
+    concat(
+        space(HeadD, <<"->">>),
+        group(nest(concat(break(<<" ">>), BodyD), ?INDENT))
+    );
 clause_to_algebra({spec_clause, _Meta, Head, [Body], Guards}) ->
     HeadD = expr_to_algebra(Head),
     GuardsD = expr_to_algebra(Guards),

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1775,8 +1775,7 @@ spec(Config) when is_list(Config) ->
         "-spec foo\n"
         "    (integer()) ->\n"
         "        some_very:very(long, type);\n"
-        "    (1..2) ->\n"
-        "        atom().",
+        "    (1..2) -> atom().",
         40
     ),
     ?assertFormat(
@@ -1786,8 +1785,7 @@ spec(Config) when is_list(Config) ->
         "        some_very_very:very(long, type)\n"
         "    when\n"
         "        Int :: integer();\n"
-        "    (1..2) ->\n"
-        "        atom().",
+        "    (1..2) -> atom().",
         40
     ),
     ?assertFormat(
@@ -1802,6 +1800,29 @@ spec(Config) when is_list(Config) ->
         "    % also non-negative, but may be float\n"
         "    L2 :: [{K, number()}],\n"
         "    K :: wa_stats:key()."
+    ),
+    ?assertFormat(
+        "-spec foo(Int) -> some_very:very(long, type) when Int :: integer().",
+        "-spec foo(Int) -> some_very:very(long, type) when\n"
+        "    Int :: integer().",
+        50
+    ),
+    ?assertFormat(
+        "-spec foo(very_long_type(), another_long_type()) -> some_very:very(long, type) when Int :: integer().",
+        "-spec foo(\n"
+        "    very_long_type(),\n"
+        "    another_long_type()\n"
+        ") -> some_very:very(long, type) when\n"
+        "    Int :: integer().",
+        50
+    ),
+    ?assertFormat(
+        "-spec foo(very_long_type(), another_long_type()) -> some_very:very(long, type).",
+        "-spec foo(\n"
+        "    very_long_type(),\n"
+        "    another_long_type()\n"
+        ") -> some_very:very(long, type).",
+        50
     ).
 
 define(Config) when is_list(Config) ->


### PR DESCRIPTION
Fixed #47