### PR TITLE
catch and print out exceptions to standard error and never used exit code 1

### DIFF
--- a/src/erlfmt_cli.erl
+++ b/src/erlfmt_cli.erl
@@ -37,6 +37,15 @@ opts() ->
 
 -spec do(list(), string()) -> ok.
 do(Opts, Name) ->
+    try do_unprotected(Opts, Name)
+    catch
+        Kind:Reason:Stack ->
+            io:format(standard_error, "~s Internal Error~n~s:~p~n~p~n", [Name, Kind, Reason, Stack]),
+            erlang:halt(127)
+    end.
+
+-spec do_unprotected(list(), string()) -> ok.
+do_unprotected(Opts, Name) ->
     case parse_opts(Opts, Name, [], #config{}) of
         {format, Files, Config} ->
             case format_files(Files, Config, _HadErrors = false) of
@@ -46,7 +55,7 @@ do(Opts, Name) ->
         {error, Message} ->
             io:put_chars(standard_error, [Message, "\n\n"]),
             getopt:usage(opts(), Name),
-            erlang:halt(1)
+            erlang:halt(2)
     end.
 
 format_files([FileName | FileNames], Config, HadErrors) ->


### PR DESCRIPTION
The reason not to use exit code 1 is that this can conflict with the `diff` tool's exit code, which uses exit code 1 to indicate that there was changes and doesn't reflect an actual error.

Since the `diff` tool can be quite commonly used with a formatter, we want this integration to be seamless on the command line
`$ erlfmt $FILE | diff -u $FILE -`