### PR TITLE
Fix dialyzer

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -103,7 +103,6 @@ to_algebra(Expr) ->
             combine_comments(Meta, Doc)
     end.
 
--spec expr_to_algebra(erlfmt_parse:abstract_expr()) -> erlfmt_algebra:doc().
 expr_to_algebra(Expr) when is_tuple(Expr) ->
     Meta = element(2, Expr),
     Doc = do_expr_to_algebra(Expr),
@@ -507,7 +506,7 @@ fun_to_algebra({function, _Anno, Mod, Name, Arity}) ->
 fun_to_algebra({clauses, _Anno, [Clause]}) ->
     ClauseD = concat(maybe_force_breaks(clause_has_break(Clause)), expr_to_algebra(Clause)),
     case Clause of
-        {clause, _Meta, {args, _, _}, _, _Body} -> group(break(concat(<<"fun">>, ClauseD), <<"end">>));
+        {clause, _, {args, _, _}, _, _} -> group(break(concat(<<"fun">>, ClauseD), <<"end">>));
         _ -> group(break(space(<<"fun">>, ClauseD), <<"end">>))
     end;
 fun_to_algebra({clauses, _Anno, Clauses}) ->

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -640,7 +640,7 @@ Erlang code.
 %% of the generated .erl file by the HiPE compiler.  Please do not remove.
 -compile([{hipe,[{regalloc,linear_scan}]}]).
 
--export_type([abstract_clause/0, abstract_expr/0, abstract_node/0,
+-export_type([abstract_expr/0, abstract_node/0,
               abstract_type/0, form_info/0, error_info/0]).
 
 %% Start of Abstract Format
@@ -674,6 +674,7 @@ Erlang code.
                        | af_map_update(abstract_expr())
                        | af_local_call()
                        | af_remote_call()
+                       | af_args(abstract_expr())
                        | af_list_comprehension()
                        | af_binary_comprehension()
                        | af_block()
@@ -694,14 +695,14 @@ Erlang code.
                               af_record_name(),
                               [af_record_field(T)]}.
 
--type af_local_call() :: {'call', anno(), af_local_function(), af_args()}.
+-type af_local_call() :: {'call', anno(), af_local_function(), [abstract_expr()]}.
 
--type af_remote_call() :: {'call', anno(), af_remote_function(abstract_expr()), af_args()}.
+-type af_remote_call() :: {'call', anno(), af_remote_function(abstract_expr()), [abstract_expr()]}  .
 
 -type af_macro_call() ::
     {'macro_call', anno(), af_atom() | af_variable(), [abstract_expr()]}.
 
--type af_args() :: [abstract_expr()].
+-type af_args(Expr) :: {args, anno(), [Expr]}.
 
 -type af_local_function() :: abstract_expr().
 
@@ -748,13 +749,9 @@ Erlang code.
     {'fun', anno(), {function, abstract_expr(), abstract_expr()}} |
     {'fun', anno(), {function, abstract_expr(), abstract_expr(), abstract_expr()}}.
 
--type abstract_clause() :: af_clause().
-
 -type af_clause() ::
-        {'clause', anno(), af_clause_name(), [af_pattern()], af_guard_seq(), af_body()} |
+        {clause, anno(), af_pattern(), af_guard_seq(), af_body()} |
         af_macro_call().
-
--type af_clause_name() :: af_atom() | af_variable() | af_macro_call() | 'fun' | 'case' | 'catch'.
 
 -type af_body() :: [abstract_expr(), ...].
 
@@ -805,6 +802,7 @@ Erlang code.
                     | af_unary_op(af_pattern())
                     | af_record_creation(af_pattern())
                     | af_record_index()
+                    | af_args(af_pattern())
                     | af_map_pattern().
 
 -type af_record_index() ::
@@ -866,10 +864,10 @@ Erlang code.
 -type af_type_variable() :: {'var', anno(), atom()}. % except '_'
 
 -type af_function_type() ::
-    {spec, anno(), af_atom() | {remote, anno(), af_atom(), af_atom()}, [af_function_clause_type()]}.
+    {spec, anno(), [af_spec_clause()]}.
 
--type af_function_clause_type() ::
-    {clause, anno(), spec, [abstract_type()], [[af_annotated_type()]], abstract_type()}.
+-type af_spec_clause() ::
+    {spec_clause, anno(), abstract_type(), af_guard_seq(), [abstract_type(), ...]}.
 
 -type af_singleton_integer_type() :: af_integer()
                                    | af_character()


### PR DESCRIPTION
The key part of the fix is removing incorrect spec from `erlfmt_format:expr_to_algebra/1`.
This function accepts much more than just "exprs" as first element, for example special,
non-standalone nodes we've introduced like `args`, `clause`, `guard_and`, ...