### PR TITLE
Make erlfmt:format_string API-compatible with erlfmt:format_file

### DIFF
--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1066,10 +1066,8 @@ range_format_exact([{Start, End} | Options], Path) ->
     range_format_exact(Options, Path).
 
 contains_pragma(Config) when is_list(Config) ->
-    ?assertEqual(
-        true,
-        erlfmt:contains_pragma_string(
-            "normalpragma.erl",
+    ?assert(
+        contains_pragma_string(
             "%% @format\n"
             "\n"
             "-module(pragma).\n"
@@ -1080,10 +1078,8 @@ contains_pragma(Config) when is_list(Config) ->
             "ok.\n"
         )
     ),
-    ?assertEqual(
-        true,
-        erlfmt:contains_pragma_string(
-            "doublelinepragma.erl",
+    ?assert(
+        contains_pragma_string(
             "\n"
             "\n"
             "%% @format\n"
@@ -1091,10 +1087,8 @@ contains_pragma(Config) when is_list(Config) ->
             "-module(pragma).\n"
         )
     ),
-    ?assertEqual(
-        false,
-        erlfmt:contains_pragma_string(
-            "nolinepragma.erl",
+    ?assertNot(
+        contains_pragma_string(
             "-module(pragma).\n"
             "-export([f/3]).\n"
             "\n"
@@ -1102,10 +1096,8 @@ contains_pragma(Config) when is_list(Config) ->
             "ok.\n"
         )
     ),
-    ?assertEqual(
-        false,
-        erlfmt:contains_pragma_string(
-            "licensenopragma.erl",
+    ?assertNot(
+        contains_pragma_string(
             "%%% LICENSE\n"
             "%%% LICENSE\n"
             "%%% LICENSE\n"
@@ -1119,10 +1111,8 @@ contains_pragma(Config) when is_list(Config) ->
             "ok.\n"
         )
     ),
-    ?assertEqual(
-        true,
-        erlfmt:contains_pragma_string(
-            "licensepragma.erl",
+    ?assert(
+        contains_pragma_string(
             "%% LICENSE\n"
             "%% LICENSE\n"
             "%% LICENSE\n"
@@ -1138,34 +1128,26 @@ contains_pragma(Config) when is_list(Config) ->
             "ok.\n"
         )
     ),
-    ?assertEqual(
-        true,
-        erlfmt:contains_pragma_string(
-            "shortpragma.erl",
+    ?assert(
+        contains_pragma_string(
             "% @format\n"
             "-module(pragma).\n"
         )
     ),
-    ?assertEqual(
-        false,
-        erlfmt:contains_pragma_string(
-            "rebar.config",
+    ?assertNot(
+        contains_pragma_string(
             "{erl_opts, [debug_info]}\n"
         )
     ),
-    ?assertEqual(
-        true,
-        erlfmt:contains_pragma_string(
-            "rebar.config",
+    ?assert(
+        contains_pragma_string(
             "%% @format\n"
             "\n"
             "{erl_opts, [debug_info]}\n"
         )
     ),
-    ?assertEqual(
-        true,
-        erlfmt:contains_pragma_string(
-            "file.escript",
+    ?assert(
+        contains_pragma_string(
             "#! /usr/bin/env escript\n"
             "\n"
             "%% @format\n"
@@ -1173,10 +1155,8 @@ contains_pragma(Config) when is_list(Config) ->
             "main(_) -> ok.\n"
         )
     ),
-    ?assertEqual(
-        false,
-        erlfmt:contains_pragma_string(
-            "file.escript",
+    ?assertNot(
+        contains_pragma_string(
             "#! /usr/bin/env escript\n"
             "\n"
             "main(_) -> ok.\n"
@@ -1280,8 +1260,11 @@ insert_pragma(Config) when is_list(Config) ->
         )
     ).
 
+contains_pragma_string(String) ->
+    skip =/= erlfmt:format_string(String, 80, require).
+
 insert_pragma_string(String) ->
-    StringWithPragma = erlfmt:format_string(String, 80, insert),
+    {ok, StringWithPragma, []} = erlfmt:format_string(String, 80, insert),
     %% check that insert_pragma_nodes doesn't insert a pragma, when one has already been inserted.
-    ?assertEqual(StringWithPragma, erlfmt:format_string(StringWithPragma, 80, insert)),
+    ?assertEqual({ok, StringWithPragma, []}, erlfmt:format_string(StringWithPragma, 80, insert)),
     StringWithPragma.

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -148,13 +148,13 @@ all() ->
 %% TEST CASES
 -define(assertSame(String), ?assertSame(String, 80)).
 -define(assertSame(String, PageWidth),
-    ?assertEqual(String, erlfmt:format_string(String, PageWidth, ignore))
+    ?assertEqual(String, format_string(String, PageWidth))
 ).
 
 -define(assertFormat(Bad, Good), ?assertFormat(Bad, Good, 80)).
 -define(assertFormat(Bad, Good, PageWidth), begin
-    ?assertEqual(Good, erlfmt:format_string(Good, PageWidth, ignore)),
-    ?assertEqual(Good, erlfmt:format_string(Bad, PageWidth, ignore))
+    ?assertEqual(Good, format_string(Good, PageWidth)),
+    ?assertEqual(Good, format_string(Bad, PageWidth))
 end).
 
 literals(Config) when is_list(Config) ->
@@ -2070,3 +2070,7 @@ comment(Config) when is_list(Config) ->
         "% foo\n"
         "1\n"
     ).
+
+format_string(String, PageWidth) ->
+    {ok, Formatted, []} = erlfmt:format_string(String, PageWidth, ignore),
+    Formatted.

--- a/test/erlfmt_markdown_SUITE.erl
+++ b/test/erlfmt_markdown_SUITE.erl
@@ -151,6 +151,5 @@ split_code_into_maps(Text, {code, Formatted, Unformatted}) ->
     end.
 
 check_fmt(Unformatted, Expected) ->
-    Got = erlfmt:format_string(Unformatted, 80, ignore),
+    {ok, Got, []} = erlfmt:format_string(Unformatted, 80, ignore),
     ?assertEqual(string:trim(Expected), string:trim(Got)).
-


### PR DESCRIPTION
This modifies format_string to expose as close of an API and return types
as it makes sense to `erlfmt:format_file`. This should also allow correctly
handling syntax errors in the passed string instead of crashing.
Additionally this adds the verification pass to `erlfmt:format_string`

Subsequently remove `erlfmt:contains_pragma_string` shrinking the size of the
public API.