### PR TITLE
Correctly handle .script files

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -218,6 +218,8 @@ do_expr_to_algebra({guard_and, _Meta, Guards}) ->
     guard_to_algebra(Guards, <<",">>);
 do_expr_to_algebra({fa_group, _Meta, GroupedExports}) ->
     fa_group_to_algebra(GroupedExports);
+do_expr_to_algebra({exprs, _Meta, Exprs}) ->
+    block_to_algebra(Exprs);
 do_expr_to_algebra(Other) ->
     error(unsupported, [Other]).
 

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -229,6 +229,9 @@ insert_nested({'catch', Meta, Args0}, Comments0) ->
 insert_nested({args, Meta, Args0}, Comments0) ->
     Args = insert_expr_container(Args0, Comments0),
     {{args, Meta, Args}, []};
+insert_nested({exprs, Meta, Exprs0}, Comments0) ->
+    Exprs = insert_expr_container(Exprs0, Comments0),
+    {{exprs, Meta, Exprs}, []};
 insert_nested({Name, Meta}, Comments) ->
     {{Name, Meta}, Comments}.
 

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -66,6 +66,7 @@
     snapshot_overlong/1,
     snapshot_otp_examples/1,
     snapshot_insert_pragma_with/1,
+    snapshot_script/1,
     simple_comments_range/1,
     comments_range/1,
     broken_range/1,
@@ -135,7 +136,8 @@ groups() ->
             snapshot_broken,
             snapshot_overlong,
             snapshot_otp_examples,
-            snapshot_insert_pragma_with
+            snapshot_insert_pragma_with,
+            snapshot_script
         ]},
         {range_tests, [parallel], [
             simple_comments_range,
@@ -999,6 +1001,8 @@ snapshot_escript(Config) -> snapshot_same("escript.erl", Config).
 snapshot_pragma(Config) -> snapshot_same("pragma.erl", [{pragma, require} | Config]).
 
 snapshot_no_pragma(Config) -> snapshot_same("no_pragma.erl", [{pragma, require} | Config]).
+
+snapshot_script(Config) -> snapshot_same("rebar.config.script", Config).
 
 snapshot_comments(Config) -> snapshot_formatted("comments.erl", Config).
 

--- a/test/erlfmt_SUITE_data/rebar.config.script
+++ b/test/erlfmt_SUITE_data/rebar.config.script
@@ -1,0 +1,14 @@
+%% Example from https://github.com/benoitc/unicode_util_compat/blob/c39aed13801374aa577b5d75a93384276f49e8aa/rebar.config.script
+_ = code:ensure_loaded(unicode_util),
+case erlang:function_exported(unicode_util, gc, 1) of
+    true ->
+        CONFIG;
+    false ->
+        [
+            {pre_hooks, [
+                {"(linux|darwin|solaris)", compile, "make -C uc_spec all"},
+                {"(freebsd|openbsd)", compile, "gmake -C uc_spec all"}
+            ]}
+            | CONFIG
+        ]
+end.

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -61,6 +61,7 @@
     spec/1,
     define/1,
     type/1,
+    exprs/1,
     comment/1,
     force_break/1
 ]).
@@ -110,7 +111,8 @@ groups() ->
             spec,
             record_definition,
             define,
-            type
+            type,
+            exprs
         ]},
         {operators, [parallel], [
             unary_operator,
@@ -2011,6 +2013,18 @@ type(Config) when is_list(Config) ->
         "            %% comment\n"
         "            bar()\n"
         "    ).\n"
+    ).
+
+exprs(Config) when is_list(Config) ->
+    ?assertSame(
+        "1,\n"
+        "2,\n"
+        "3.\n"
+    ),
+    ?assertSame(
+        "1,\n"
+        "2,\n"
+        "3\n"
     ).
 
 comment(Config) when is_list(Config) ->


### PR DESCRIPTION
They can have multiple expressions between each dot, unlike .config files.
Add a special top-level exprs node to handle that situation.