### PR TITLE
erlfmt_format: preserve empty lines between values in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,24 +214,18 @@ the collection will be always printed "expanded", for example:
 ]
 ```
 
-will be preserved, even though it could fit on a single line. The fact that
-this is controlled by a single newline, allows you to easily convert between
-those layouts, for example, merely deleting the first newline from the above
-sequence to have:
+will be preserved, even though it could fit on a single line.
+This is controlled by whether the user has included a newline in the original version.
+For example, merely deleting the newlines from the above sequence:
 
 ```erl unformatted foobar1
-[    Foo,
-    Bar
-]
+[    Foo, Bar]
 ```
 
 and re-running the formatter, will produce:
 
 ```erl formatted foobar1
-[
-    Foo,
-    Bar
-]
+[Foo, Bar]
 ```
 
 Similarly, adding the single newline back:

--- a/README.md
+++ b/README.md
@@ -228,7 +228,10 @@ sequence to have:
 and re-running the formatter, will produce:
 
 ```erl formatted foobar1
-[Foo, Bar]
+[
+    Foo,
+    Bar
+]
 ```
 
 Similarly, adding the single newline back:

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -515,7 +515,7 @@ fa_group_to_algebra([Value1, Value2 | _] = Values) ->
 % for example: -export([a/1, a/2, b/1]) => -export([{fa_group, _, [a/1, a/2]}, b/1])
 fa_groups([]) ->
     [];
-fa_groups([{op, Meta, '/', {atom, _, HeadFunction}, _} = Head0 | Tail]) ->
+fa_groups([{op, Meta0, '/', {atom, _, HeadFunction}, _} = Head0 | Tail]) ->
     Splitter = fun
         ({op, _, '/', {atom, _, Function}, _}) -> Function =:= HeadFunction;
         (_) -> false
@@ -525,6 +525,8 @@ fa_groups([{op, Meta, '/', {atom, _, HeadFunction}, _} = Head0 | Tail]) ->
             [Head0 | fa_groups(Rest)];
         {Group, Rest} ->
             Head = erlfmt_scan:delete_annos([pre_comments, post_comments], Head0),
+            EndLoc = erlfmt_scan:get_end_location(lists:last(Group)),
+            Meta = erlfmt_scan:set_end_location(EndLoc, Meta0),
             [{fa_group, Meta, [Head | Group]} | fa_groups(Rest)]
     end;
 fa_groups([Other | Tail]) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -353,10 +353,35 @@ container_common(Meta, Values, Left, Right, Break, LastFits0) ->
     Doc = container_inner_values(SplitValues, BreakFun, LastFits),
     surround_container_values(Left, Doc, Right, HasLineBreak, Break, LastFits).
 
-%% last_fits checks whether last_fits is wanted, given the last value is next break fits and there are no trailing comments.
+-record(split_values, {
+    init_values :: [erlfmt_parse:abstract_form()],
+    last_value :: undefined | erlfmt_parse:abstract_form(),
+    trailing_comments :: [erlfmt_parse:abstract_form()]
+}).
+
+%% init_last_and_comments splits the list of container values into the initial values,
+%% the possible last value and the trailing comments.
+-spec init_last_and_comments([erlfmt_parse:abstract_form()]) -> #split_values{}.
+init_last_and_comments(Values) ->
+    init_last_and_comments(Values, []).
+-spec init_last_and_comments([erlfmt_parse:abstract_form()], [erlfmt_parse:abstract_form()]) -> #split_values{}.
+init_last_and_comments([], []) ->
+    #split_values{init_values=[], last_value=undefined, trailing_comments=[]};
+init_last_and_comments([{comment, _, _} | _] = Comments, Acc) ->
+    #split_values{init_values = lists:reverse(Acc), last_value = undefined, trailing_comments = Comments};
+init_last_and_comments([Last | [{comment, _, _} | _] = Comments], Acc) ->
+    #split_values{init_values=lists:reverse(Acc), last_value=Last, trailing_comments=Comments};
+init_last_and_comments([Last], Acc) ->
+    #split_values{init_values=lists:reverse(Acc), last_value=Last, trailing_comments=[]};
+init_last_and_comments([H | T], Acc) ->
+    init_last_and_comments(T, [H | Acc]).
+
+%% last_fits checks whether last_fits is wanted,
+%% given the last value is next break fits and there are no trailing comments.
+-spec last_fits(last_normal | last_fits, #split_values{}) -> last_normal | last_fits.
 last_fits(last_normal, _) -> last_normal;
-last_fits(last_fits, {_, undefined, _}) -> last_normal;
-last_fits(last_fits, {_, LastValue, []}) ->
+last_fits(last_fits, #split_values{last_value=undefined}) -> last_normal;
+last_fits(last_fits, #split_values{last_value=LastValue, trailing_comments=[]}) ->
     case is_next_break_fits(LastValue) of
         true -> last_fits;
         false -> last_normal
@@ -364,12 +389,16 @@ last_fits(last_fits, {_, LastValue, []}) ->
 last_fits(last_fits, _) -> last_normal.
 
 %% has_line_break is true if there is an inner break or the values have a trailing comment.
-has_line_break(_Meta, {_, _, [_Comment | _]}) -> true;
-has_line_break(_Meta, {[], undefined, []}) -> false;
-has_line_break(Meta, {[HeadValue | _], _, []}) -> has_inner_break(Meta, HeadValue);
-has_line_break(Meta, {[], OnlyValue, []}) -> has_inner_break(Meta, OnlyValue).
+-spec has_line_break(erlfmt_parse:abstract_form(), #split_values{}) -> boolean().
+has_line_break(_Meta, #split_values{trailing_comments=[_Comment | _]}) -> true;
+has_line_break(_Meta, #split_values{init_values=[], last_value=undefined}) -> false;
+has_line_break(Meta, #split_values{init_values=[HeadValue | _]}) -> has_inner_break(Meta, HeadValue);
+has_line_break(Meta, #split_values{init_values=[], last_value=OnlyValue}) -> has_inner_break(Meta, OnlyValue).
+
+-type doc_combo_fun() :: fun((erlfmt_algebra:doc(), erlfmt_algebra:doc()) -> erlfmt_algebra:doc()).
 
 %% break_to_fun returns a break function/2.
+-spec break_fun(break | flex_break, boolean()) -> doc_combo_fun().
 break_fun(Break, HasLineBreak) ->
     case {Break, HasLineBreak} of
         {_, true} ->
@@ -378,6 +407,50 @@ break_fun(Break, HasLineBreak) ->
             fun erlfmt_algebra:break/2;
         {flex_break, _} ->
             fun erlfmt_algebra:flex_break/2
+    end.
+
+%% container_inner_values combines the splitted values of a container into a single doc.
+-spec container_inner_values(#split_values{}, doc_combo_fun(), last_normal | last_fits)
+    -> erlfmt_algebra:doc().
+container_inner_values(#split_values{init_values=InitValues, last_value=MaybeLastValue, trailing_comments=Comments}, BreakFun, Last) ->
+    {LastValue, LastValueD0} = combine_last_and_comments(MaybeLastValue, Comments),
+    LastValueD = case Last of
+        last_fits -> next_break_fits(LastValueD0, enabled);
+        last_normal -> LastValueD0
+    end,
+    InitValuesVD = lists:map(fun(V) -> {V, expr_to_algebra(V)} end, InitValues),
+    ValuesVD = InitValuesVD ++ [{LastValue, LastValueD}],
+    fold_inner_values(BreakFun, ValuesVD).
+
+-type value_doc_pair() :: {erlfmt_parse:abstract_form(), erlfmt_algebra:doc()}.
+
+%% combine_last_and_comments combines the possible last value and trailing comments of a container.
+%% It returns the first value and the combined document.
+-spec combine_last_and_comments(
+    undefined | erlfmt_parse:abstract_form(),
+    [erlfmt_parse:abstract_form()])
+->
+    value_doc_pair().
+combine_last_and_comments(undefined, [FirstComment | _ ] = Comments) ->
+    {FirstComment, concat(force_breaks(), comments_to_algebra(Comments))};
+combine_last_and_comments(Value, [FirstComment | _ ] = Comments) ->
+    Doc = case has_empty_line_between(Value, FirstComment) of
+        true -> concat(expr_to_algebra(Value), line(2), comments_to_algebra(Comments));
+        false -> concat(expr_to_algebra(Value),line(), comments_to_algebra(Comments))
+    end,
+    {Value, concat(force_breaks(), Doc)};
+combine_last_and_comments(Value, []) ->
+    {Value, expr_to_algebra(Value)}.
+
+%% fold_inner_values combines pairs of values and their document representation into one document.
+%% It preserves empty lines and adds commas between documents.
+-spec fold_inner_values(doc_combo_fun(), [value_doc_pair()]) -> erlfmt_algebra:doc().
+fold_inner_values(_BreakFun, [{_, ValueD}]) ->
+    ValueD;
+fold_inner_values(BreakFun, [{Value, ValueD} | [{Value2, _ValueD2} | _] = ValuesVD]) ->
+    case has_empty_line_between(Value, Value2) of
+        true -> concat([ValueD, <<",">>, line(2), fold_inner_values(BreakFun, ValuesVD)]);
+        false -> BreakFun(concat(ValueD, <<",">>), fold_inner_values(BreakFun, ValuesVD))
     end.
 
 %% surround_container_values surrounds the doc created from container inner values.
@@ -392,47 +465,6 @@ surround_container_values(Left, Doc, Right, _, Combine, Last) ->
         last_fits -> next_break_fits(Wrapped, disabled);
         last_normal -> Wrapped
     end.
-
-%% container_inner_values combines the splitted values of a container into a single doc.
-container_inner_values({InitValues, LastValue, Comments}, BreakFun, Last) ->
-    LastValueD = case Last of
-        last_fits -> next_break_fits(combine_last_and_comments(LastValue, Comments), enabled);
-        last_normal -> combine_last_and_comments(LastValue, Comments)
-    end,
-    InitValuesVD = lists:map(fun(V) -> {V, expr_to_algebra(V)} end, InitValues),
-    ValuesVD = InitValuesVD ++ [{LastValue, LastValueD}],
-    fold_inner_values(BreakFun, ValuesVD).
-
-%% fold_inner_values combines pairs of values and their document representation into one document.
-%% It preserves empty lines and adds commas between documents.
-fold_inner_values(_BreakFun, []) -> empty();
-fold_inner_values(_BreakFun, [{_Value, ValueD}]) ->
-    ValueD;
-fold_inner_values(BreakFun, [{Value, ValueD} | [{Value2, _Value2D} | _] = ValuesVD]) ->
-    case has_empty_line_between(Value, Value2) of
-        true -> concat([ValueD, <<",">>, line(2), fold_inner_values(BreakFun, ValuesVD)]);
-        false -> BreakFun(concat(ValueD, <<",">>), fold_inner_values(BreakFun, ValuesVD))
-    end.
-
-%% combine_last_and_comments combines the possible last value and trailing comments of a container and returns a document.
-combine_last_and_comments(undefined, [_FirstComment | _ ] = Comments) ->
-    concat(force_breaks(), comments_to_algebra(Comments));
-combine_last_and_comments(Value, [FirstComment | _ ] = Comments) ->
-    Doc = case has_empty_line_between(Value, FirstComment) of
-        true -> concat(expr_to_algebra(Value), line(2), comments_to_algebra(Comments));
-        false -> concat(expr_to_algebra(Value),line(), comments_to_algebra(Comments))
-    end,
-    concat(force_breaks(), Doc);
-combine_last_and_comments(Value, []) ->
-    expr_to_algebra(Value).
-
-%% init_last_and_comments splits the list of container values into the initial values, the possible last value and the trailing comments.
-init_last_and_comments(Values) -> init_last_and_comments(Values, []).
-init_last_and_comments([], []) -> {[], undefined, []};
-init_last_and_comments([{comment, _, _} | _] = Comments, Acc) -> {lists:reverse(Acc), undefined, Comments};
-init_last_and_comments([Last | [{comment, _, _} | _] = Comments], Acc) -> {lists:reverse(Acc), Last, Comments};
-init_last_and_comments([Last], Acc) -> {lists:reverse(Acc), Last, []};
-init_last_and_comments([H | T], Acc) -> init_last_and_comments(T, [H | Acc]).
 
 % fa_group_to_algebra, see fa_groups/1 that creates function/arity groups.
 fa_group_to_algebra([Value1, Value2 | _] = Values) ->
@@ -503,10 +535,13 @@ field_to_algebra(Op, Key, Value) ->
 
 comprehension_to_algebra(Expr, LcExprs, Left, Right) ->
     ExprD = expr_to_algebra(Expr),
-    Values = LcExprs,
-    {InitValues, LastValue, TrailingComments} = init_last_and_comments(Values),
-    LastValueD = combine_last_and_comments(LastValue, TrailingComments),
-    LcExprsD = lists:map(fun expr_to_algebra/1, InitValues) ++ [LastValueD],
+    #split_values{
+        init_values=InitExprs,
+        last_value=LastExpr,
+        trailing_comments=TrailingComments
+    } = init_last_and_comments(LcExprs),
+    {_LastExpr, LastExprD} = combine_last_and_comments(LastExpr, TrailingComments),
+    LcExprsD = lists:map(fun expr_to_algebra/1, InitExprs) ++ [LastExprD],
     LcExprD = fold_doc(fun(D, Acc) -> break(concat(D, <<",">>), Acc) end, LcExprsD),
     Doc = concat([ExprD, break(<<" ">>), <<"||">>, <<" ">>, nest(group(LcExprD), 3)]),
     surround(Left, <<"">>, Doc, <<"">>, Right).

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -519,8 +519,7 @@ fa_groups([{op, Meta0, '/', {atom, _, HeadFunction}, _} = Head0 | Tail]) ->
             [Head0 | fa_groups(Rest)];
         {Group, Rest} ->
             Head = erlfmt_scan:delete_annos([pre_comments, post_comments], Head0),
-            EndLoc = erlfmt_scan:get_end_location(lists:last(Group)),
-            Meta = erlfmt_scan:set_end_location(EndLoc, Meta0),
+            Meta = erlfmt_scan:range_anno(Meta0, lists:last(Group)),
             [{fa_group, Meta, [Head | Group]} | fa_groups(Rest)]
     end;
 fa_groups([Other | Tail]) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -351,8 +351,9 @@ container_common(Meta, Values, Left, Right, Break, LastFits0) ->
     LastFits = last_fits(LastFits0, SplitValues),
     HasLineBreak = has_line_break(Meta, SplitValues),
     BreakFun = break_fun(Break, HasLineBreak),
+    SurroundFun = surround_fun(HasLineBreak, Break, LastFits),
     Doc = container_inner_values(SplitValues, BreakFun, LastFits),
-    surround_container_values(Left, Doc, Right, HasLineBreak, Break, LastFits).
+    SurroundFun(Left, Doc, Right).
 
 -record(split_values, {
     init_values :: [erlfmt_parse:abstract_form()],
@@ -480,18 +481,20 @@ fold_inner_values(BreakFun, [{Value, ValueD} | [{Value2, _ValueD2} | _] = Values
         false -> BreakFun(concat(ValueD, <<",">>), fold_inner_values(BreakFun, ValuesVD))
     end.
 
-%% surround_container_values surrounds the doc created from container inner values.
-surround_container_values(Left, Doc, Right, true, _Combine, _Last) ->
-    surround(Left, <<"">>, concat(force_breaks(), Doc), <<"">>, Right);
-surround_container_values(Left, Doc, Right, _, Combine, Last) ->
-    Wrapped =
+%% surround_fun returns a function that surrounds the doc created from container inner values.
+surround_fun(true, _Combine, _Last) ->
+    fun(Left, Doc, Right) -> surround(Left, <<"">>, concat(force_breaks(), Doc), <<"">>, Right) end;
+surround_fun(_HasLineBreak, Combine, Last) ->
+    fun(Left, Doc, Right) ->
+        Wrapped =
         case Combine of
             break -> surround(Left, <<"">>, Doc, <<"">>, Right);
             flex_break -> group(concat(nest(concat(Left, Doc), ?INDENT, break), Right))
         end,
-    case Last of
-        last_fits -> next_break_fits(Wrapped, disabled);
-        last_normal -> Wrapped
+        case Last of
+            last_fits -> next_break_fits(Wrapped, disabled);
+            last_normal -> Wrapped
+        end
     end.
 
 % fa_group_to_algebra, see fa_groups/1 that creates function/arity groups.

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -423,15 +423,9 @@ has_line_break(Meta, #split_values{init_values = [], last_value = OnlyValue}) ->
 
 %% break_to_fun returns a break function/2.
 -spec break_fun(break | flex_break, boolean()) -> doc_combo_fun().
-break_fun(Break, HasLineBreak) ->
-    case {Break, HasLineBreak} of
-        {_, true} ->
-            fun erlfmt_algebra:line/2;
-        {break, _} ->
-            fun erlfmt_algebra:break/2;
-        {flex_break, _} ->
-            fun erlfmt_algebra:flex_break/2
-    end.
+break_fun(_, true) -> fun erlfmt_algebra:line/2;
+break_fun(break, _) -> fun erlfmt_algebra:break/2;
+break_fun(flex_break, _) -> fun erlfmt_algebra:flex_break/2.
 
 %% container_inner_values combines the splitted values of a container into a single doc.
 -spec container_inner_values(#split_values{}, doc_combo_fun(), last_normal | last_fits) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -344,7 +344,8 @@ flex_container(Meta, Values, Left, Right) ->
 call(Meta, Values, Left, Right) ->
     container_common(Meta, Values, Left, Right, break, last_fits).
 
-container_common(_Meta, [], Left, Right, _, _) -> concat(Left, Right);
+container_common(_Meta, [], Left, Right, _, _) ->
+    concat(Left, Right);
 container_common(Meta, Values, Left, Right, Break, LastFits0) ->
     SplitValues = init_last_and_comments(Values),
     LastFits = last_fits(LastFits0, SplitValues),
@@ -364,38 +365,61 @@ container_common(Meta, Values, Left, Right, Break, LastFits0) ->
 -spec init_last_and_comments([erlfmt_parse:abstract_form()]) -> #split_values{}.
 init_last_and_comments(Values) ->
     init_last_and_comments(Values, []).
--spec init_last_and_comments([erlfmt_parse:abstract_form()], [erlfmt_parse:abstract_form()]) -> #split_values{}.
+
+-spec init_last_and_comments([erlfmt_parse:abstract_form()], [erlfmt_parse:abstract_form()]) ->
+    #split_values{}.
 init_last_and_comments([], []) ->
-    #split_values{init_values=[], last_value=undefined, trailing_comments=[]};
+    #split_values{init_values = [], last_value = undefined, trailing_comments = []};
 init_last_and_comments([{comment, _, _} | _] = Comments, Acc) ->
-    #split_values{init_values = lists:reverse(Acc), last_value = undefined, trailing_comments = Comments};
+    #split_values{
+        init_values = lists:reverse(Acc),
+        last_value = undefined,
+        trailing_comments = Comments
+    };
 init_last_and_comments([Last | [{comment, _, _} | _] = Comments], Acc) ->
-    #split_values{init_values=lists:reverse(Acc), last_value=Last, trailing_comments=Comments};
+    #split_values{
+        init_values = lists:reverse(Acc),
+        last_value = Last,
+        trailing_comments = Comments
+    };
 init_last_and_comments([Last], Acc) ->
-    #split_values{init_values=lists:reverse(Acc), last_value=Last, trailing_comments=[]};
+    #split_values{
+        init_values = lists:reverse(Acc),
+        last_value = Last,
+        trailing_comments = []
+    };
 init_last_and_comments([H | T], Acc) ->
     init_last_and_comments(T, [H | Acc]).
 
 %% last_fits checks whether last_fits is wanted,
 %% given the last value is next break fits and there are no trailing comments.
 -spec last_fits(last_normal | last_fits, #split_values{}) -> last_normal | last_fits.
-last_fits(last_normal, _) -> last_normal;
-last_fits(last_fits, #split_values{last_value=undefined}) -> last_normal;
-last_fits(last_fits, #split_values{last_value=LastValue, trailing_comments=[]}) ->
+last_fits(last_normal, _) ->
+    last_normal;
+last_fits(last_fits, #split_values{last_value = undefined}) ->
+    last_normal;
+last_fits(last_fits, #split_values{last_value = LastValue, trailing_comments = []}) ->
     case is_next_break_fits(LastValue) of
         true -> last_fits;
         false -> last_normal
     end;
-last_fits(last_fits, _) -> last_normal.
+last_fits(last_fits, _) ->
+    last_normal.
 
 %% has_line_break is true if there is an inner break or the values have a trailing comment.
 -spec has_line_break(erlfmt_parse:abstract_form(), #split_values{}) -> boolean().
-has_line_break(_Meta, #split_values{trailing_comments=[_Comment | _]}) -> true;
-has_line_break(_Meta, #split_values{init_values=[], last_value=undefined}) -> false;
-has_line_break(Meta, #split_values{init_values=[HeadValue | _]}) -> has_inner_break(Meta, HeadValue);
-has_line_break(Meta, #split_values{init_values=[], last_value=OnlyValue}) -> has_inner_break(Meta, OnlyValue).
+has_line_break(_Meta, #split_values{trailing_comments = [_Comment | _]}) ->
+    true;
+has_line_break(_Meta, #split_values{init_values = [], last_value = undefined}) ->
+    false;
+has_line_break(Meta, #split_values{init_values = [HeadValue | _]}) ->
+    has_inner_break(Meta, HeadValue);
+has_line_break(Meta, #split_values{init_values = [], last_value = OnlyValue}) ->
+    has_inner_break(Meta, OnlyValue).
 
--type doc_combo_fun() :: fun((erlfmt_algebra:doc(), erlfmt_algebra:doc()) -> erlfmt_algebra:doc()).
+-type doc_combo_fun() :: fun((erlfmt_algebra:doc(), erlfmt_algebra:doc()) ->
+        erlfmt_algebra:doc()
+).
 
 %% break_to_fun returns a break function/2.
 -spec break_fun(break | flex_break, boolean()) -> doc_combo_fun().
@@ -410,14 +434,23 @@ break_fun(Break, HasLineBreak) ->
     end.
 
 %% container_inner_values combines the splitted values of a container into a single doc.
--spec container_inner_values(#split_values{}, doc_combo_fun(), last_normal | last_fits)
-    -> erlfmt_algebra:doc().
-container_inner_values(#split_values{init_values=InitValues, last_value=MaybeLastValue, trailing_comments=Comments}, BreakFun, Last) ->
+-spec container_inner_values(#split_values{}, doc_combo_fun(), last_normal | last_fits) ->
+    erlfmt_algebra:doc().
+container_inner_values(
+    #split_values{
+        init_values = InitValues,
+        last_value = MaybeLastValue,
+        trailing_comments = Comments
+    },
+    BreakFun,
+    Last
+) ->
     {LastValue, LastValueD0} = combine_last_and_comments(MaybeLastValue, Comments),
-    LastValueD = case Last of
-        last_fits -> next_break_fits(LastValueD0, enabled);
-        last_normal -> LastValueD0
-    end,
+    LastValueD =
+        case Last of
+            last_fits -> next_break_fits(LastValueD0, enabled);
+            last_normal -> LastValueD0
+        end,
     InitValuesVD = lists:map(fun(V) -> {V, expr_to_algebra(V)} end, InitValues),
     ValuesVD = InitValuesVD ++ [{LastValue, LastValueD}],
     fold_inner_values(BreakFun, ValuesVD).
@@ -428,16 +461,16 @@ container_inner_values(#split_values{init_values=InitValues, last_value=MaybeLas
 %% It returns the first value and the combined document.
 -spec combine_last_and_comments(
     undefined | erlfmt_parse:abstract_form(),
-    [erlfmt_parse:abstract_form()])
-->
-    value_doc_pair().
-combine_last_and_comments(undefined, [FirstComment | _ ] = Comments) ->
+    [erlfmt_parse:abstract_form()]
+) -> value_doc_pair().
+combine_last_and_comments(undefined, [FirstComment | _] = Comments) ->
     {FirstComment, concat(force_breaks(), comments_to_algebra(Comments))};
-combine_last_and_comments(Value, [FirstComment | _ ] = Comments) ->
-    Doc = case has_empty_line_between(Value, FirstComment) of
-        true -> concat(expr_to_algebra(Value), line(2), comments_to_algebra(Comments));
-        false -> concat(expr_to_algebra(Value),line(), comments_to_algebra(Comments))
-    end,
+combine_last_and_comments(Value, [FirstComment | _] = Comments) ->
+    Doc =
+        case has_empty_line_between(Value, FirstComment) of
+            true -> concat(expr_to_algebra(Value), line(2), comments_to_algebra(Comments));
+            false -> concat(expr_to_algebra(Value), line(), comments_to_algebra(Comments))
+        end,
     {Value, concat(force_breaks(), Doc)};
 combine_last_and_comments(Value, []) ->
     {Value, expr_to_algebra(Value)}.
@@ -457,10 +490,11 @@ fold_inner_values(BreakFun, [{Value, ValueD} | [{Value2, _ValueD2} | _] = Values
 surround_container_values(Left, Doc, Right, true, _Combine, _Last) ->
     surround(Left, <<"">>, concat(force_breaks(), Doc), <<"">>, Right);
 surround_container_values(Left, Doc, Right, _, Combine, Last) ->
-    Wrapped = case Combine of
-        break -> surround(Left, <<"">>, Doc, <<"">>, Right);
-        flex_break -> group(concat(nest(concat(Left, Doc), ?INDENT, break), Right))
-    end,
+    Wrapped =
+        case Combine of
+            break -> surround(Left, <<"">>, Doc, <<"">>, Right);
+            flex_break -> group(concat(nest(concat(Left, Doc), ?INDENT, break), Right))
+        end,
     case Last of
         last_fits -> next_break_fits(Wrapped, disabled);
         last_normal -> Wrapped
@@ -536,9 +570,9 @@ field_to_algebra(Op, Key, Value) ->
 comprehension_to_algebra(Expr, LcExprs, Left, Right) ->
     ExprD = expr_to_algebra(Expr),
     #split_values{
-        init_values=InitExprs,
-        last_value=LastExpr,
-        trailing_comments=TrailingComments
+        init_values = InitExprs,
+        last_value = LastExpr,
+        trailing_comments = TrailingComments
     } = init_last_and_comments(LcExprs),
     {_LastExpr, LastExprD} = combine_last_and_comments(LastExpr, TrailingComments),
     LcExprsD = lists:map(fun expr_to_algebra/1, InitExprs) ++ [LastExprD],

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -344,57 +344,95 @@ flex_container(Meta, Values, Left, Right) ->
 call(Meta, Values, Left, Right) ->
     container_common(Meta, Values, Left, Right, break, last_fits).
 
-container_common(_Meta, [], Left, Right, _Combine, _Last) ->
-    concat(Left, Right);
-container_common(Meta, [Value | _] = Values, Left, Right, Combine, Last) ->
-    {HasTrailingComments, WasLastFits, ValuesD} =
-        container_exprs_to_algebra(Values, Last, []),
-    case HasTrailingComments orelse has_inner_break(Meta, Value) of
-        true ->
-            Doc = fold_doc(fun (D, Acc) -> line(concat(D, <<",">>), Acc) end, ValuesD),
-            surround(Left, <<"">>, concat(force_breaks(), Doc), <<"">>, Right);
-        false when Combine =:= break ->
-            Doc = fold_doc(fun (D, Acc) -> break(concat(D, <<",">>), Acc) end, ValuesD),
-            Wrapped = surround(Left, <<"">>, Doc, <<"">>, Right),
-            case WasLastFits of
-                true -> next_break_fits(Wrapped, disabled);
-                false -> Wrapped
-            end;
-        false when Combine =:= flex_break ->
-            Doc = fold_doc(
-                fun (D, Acc) -> flex_break(concat(D, <<",">>), Acc) end,
-                ValuesD
-            ),
-            Wrapped = group(concat(nest(concat(Left, Doc), ?INDENT, break), Right)),
-            case WasLastFits of
-                true -> next_break_fits(Wrapped, disabled);
-                false -> Wrapped
-            end
+container_common(_Meta, [], Left, Right, _, _) -> concat(Left, Right);
+container_common(Meta, Values, Left, Right, Break, LastFits0) ->
+    SplitValues = init_last_and_comments(Values),
+    LastFits = last_fits(LastFits0, SplitValues),
+    HasLineBreak = has_line_break(Meta, SplitValues),
+    BreakFun = break_fun(Break, HasLineBreak),
+    Doc = container_inner_values(SplitValues, BreakFun, LastFits),
+    surround_container_values(Left, Doc, Right, HasLineBreak, Break, LastFits).
+
+%% last_fits checks whether last_fits is wanted, given the last value is next break fits and there are no trailing comments.
+last_fits(last_normal, _) -> last_normal;
+last_fits(last_fits, {_, undefined, _}) -> last_normal;
+last_fits(last_fits, {_, LastValue, []}) ->
+    case is_next_break_fits(LastValue) of
+        true -> last_fits;
+        false -> last_normal
+    end;
+last_fits(last_fits, _) -> last_normal.
+
+%% has_line_break is true if there is an inner break or the values have a trailing comment.
+has_line_break(_Meta, {_, _, [_Comment | _]}) -> true;
+has_line_break(_Meta, {[], undefined, []}) -> false;
+has_line_break(Meta, {[HeadValue | _], _, []}) -> has_inner_break(Meta, HeadValue);
+has_line_break(Meta, {[], OnlyValue, []}) -> has_inner_break(Meta, OnlyValue).
+
+%% break_to_fun returns a break function/2.
+break_fun(Break, HasLineBreak) ->
+    case {Break, HasLineBreak} of
+        {_, true} ->
+            fun erlfmt_algebra:line/2;
+        {break, _} ->
+            fun erlfmt_algebra:break/2;
+        {flex_break, _} ->
+            fun erlfmt_algebra:flex_break/2
     end.
 
-container_exprs_to_algebra([{comment, _, _} | _] = Comments, _Last, Acc) ->
-    {true, false,
-        lists:reverse(Acc, [concat(force_breaks(), comments_to_algebra(Comments))])};
-container_exprs_to_algebra([Value, {comment, _, _} = FirstComment | Rest], _Last, Acc) ->
-    Comments = [FirstComment | Rest],
-    Doc =
-        case has_empty_line_between(Value, FirstComment) of
-            true -> concat(expr_to_algebra(Value), line(2), comments_to_algebra(Comments));
-            false -> concat(expr_to_algebra(Value), line(), comments_to_algebra(Comments))
-        end,
-    {true, false, lists:reverse(Acc, [concat(force_breaks(), Doc)])};
-container_exprs_to_algebra([Value], last_fits, Acc) ->
-    IsNextBreakFits = is_next_break_fits(Value),
-    ValueD =
-        case IsNextBreakFits of
-            true -> next_break_fits(expr_to_algebra(Value), enabled);
-            false -> expr_to_algebra(Value)
-        end,
-    {false, IsNextBreakFits, lists:reverse(Acc, [ValueD])};
-container_exprs_to_algebra([Value], last_normal, Acc) ->
-    {false, false, lists:reverse(Acc, [expr_to_algebra(Value)])};
-container_exprs_to_algebra([Value | Values], Last, Acc) ->
-    container_exprs_to_algebra(Values, Last, [expr_to_algebra(Value) | Acc]).
+%% surround_container_values surrounds the doc created from container inner values.
+surround_container_values(Left, Doc, Right, true, _Combine, _Last) ->
+    surround(Left, <<"">>, concat(force_breaks(), Doc), <<"">>, Right);
+surround_container_values(Left, Doc, Right, _, Combine, Last) ->
+    Wrapped = case Combine of
+        break -> surround(Left, <<"">>, Doc, <<"">>, Right);
+        flex_break -> group(concat(nest(concat(Left, Doc), ?INDENT, break), Right))
+    end,
+    case Last of
+        last_fits -> next_break_fits(Wrapped, disabled);
+        last_normal -> Wrapped
+    end.
+
+%% container_inner_values combines the splitted values of a container into a single doc.
+container_inner_values({InitValues, LastValue, Comments}, BreakFun, Last) ->
+    LastValueD = case Last of
+        last_fits -> next_break_fits(combine_last_and_comments(LastValue, Comments), enabled);
+        last_normal -> combine_last_and_comments(LastValue, Comments)
+    end,
+    InitValuesVD = lists:map(fun(V) -> {V, expr_to_algebra(V)} end, InitValues),
+    ValuesVD = InitValuesVD ++ [{LastValue, LastValueD}],
+    fold_inner_values(BreakFun, ValuesVD).
+
+%% fold_inner_values combines pairs of values and their document representation into one document.
+%% It preserves empty lines and adds commas between documents.
+fold_inner_values(_BreakFun, []) -> empty();
+fold_inner_values(_BreakFun, [{_Value, ValueD}]) ->
+    ValueD;
+fold_inner_values(BreakFun, [{Value, ValueD} | [{Value2, _Value2D} | _] = ValuesVD]) ->
+    case has_empty_line_between(Value, Value2) of
+        true -> concat([ValueD, <<",">>, line(2), fold_inner_values(BreakFun, ValuesVD)]);
+        false -> BreakFun(concat(ValueD, <<",">>), fold_inner_values(BreakFun, ValuesVD))
+    end.
+
+%% combine_last_and_comments combines the possible last value and trailing comments of a container and returns a document.
+combine_last_and_comments(undefined, [_FirstComment | _ ] = Comments) ->
+    concat(force_breaks(), comments_to_algebra(Comments));
+combine_last_and_comments(Value, [FirstComment | _ ] = Comments) ->
+    Doc = case has_empty_line_between(Value, FirstComment) of
+        true -> concat(expr_to_algebra(Value), line(2), comments_to_algebra(Comments));
+        false -> concat(expr_to_algebra(Value),line(), comments_to_algebra(Comments))
+    end,
+    concat(force_breaks(), Doc);
+combine_last_and_comments(Value, []) ->
+    expr_to_algebra(Value).
+
+%% init_last_and_comments splits the list of container values into the initial values, the possible last value and the trailing comments.
+init_last_and_comments(Values) -> init_last_and_comments(Values, []).
+init_last_and_comments([], []) -> {[], undefined, []};
+init_last_and_comments([{comment, _, _} | _] = Comments, Acc) -> {lists:reverse(Acc), undefined, Comments};
+init_last_and_comments([Last | [{comment, _, _} | _] = Comments], Acc) -> {lists:reverse(Acc), Last, Comments};
+init_last_and_comments([Last], Acc) -> {lists:reverse(Acc), Last, []};
+init_last_and_comments([H | T], Acc) -> init_last_and_comments(T, [H | Acc]).
 
 % fa_group_to_algebra, see fa_groups/1 that creates function/arity groups.
 fa_group_to_algebra([Value1, Value2 | _] = Values) ->
@@ -465,9 +503,11 @@ field_to_algebra(Op, Key, Value) ->
 
 comprehension_to_algebra(Expr, LcExprs, Left, Right) ->
     ExprD = expr_to_algebra(Expr),
-    {_HasTrailingComment, _WasLastFits, LcExprsD} =
-        container_exprs_to_algebra(LcExprs, last_normal, []),
-    LcExprD = fold_doc(fun (D, Acc) -> break(concat(D, <<",">>), Acc) end, LcExprsD),
+    Values = LcExprs,
+    {InitValues, LastValue, TrailingComments} = init_last_and_comments(Values),
+    LastValueD = combine_last_and_comments(LastValue, TrailingComments),
+    LcExprsD = lists:map(fun expr_to_algebra/1, InitValues) ++ [LastValueD],
+    LcExprD = fold_doc(fun(D, Acc) -> break(concat(D, <<",">>), Acc) end, LcExprsD),
     Doc = concat([ExprD, break(<<" ">>), <<"||">>, <<" ">>, nest(group(LcExprD), 3)]),
     surround(Left, <<"">>, Doc, <<"">>, Right).
 

--- a/src/erlfmt_scan.erl
+++ b/src/erlfmt_scan.erl
@@ -28,6 +28,8 @@
     get_inner_line/1,
     get_inner_end_line/1,
     update_anno/3,
+    get_end_location/1,
+    set_end_location/2,
     read_rest/1
 ]).
 
@@ -291,6 +293,10 @@ delete_annos(Keys, Node) when is_tuple(Node) ->
 get_line(Anno) -> element(1, get_anno(location, Anno)).
 
 get_end_line(Anno) -> element(1, get_anno(end_location, Anno)).
+
+get_end_location(Anno) -> get_anno(end_location, Anno).
+
+set_end_location(EndLine, Anno) -> put_anno(end_location, EndLine, Anno).
 
 get_inner_line(Anno) ->
     element(1, get_anno(inner_location, Anno, get_anno(location, Anno))).

--- a/src/erlfmt_scan.erl
+++ b/src/erlfmt_scan.erl
@@ -28,8 +28,7 @@
     get_inner_line/1,
     get_inner_end_line/1,
     update_anno/3,
-    get_end_location/1,
-    set_end_location/2,
+    range_anno/2,
     read_rest/1
 ]).
 
@@ -294,10 +293,6 @@ get_line(Anno) -> element(1, get_anno(location, Anno)).
 
 get_end_line(Anno) -> element(1, get_anno(end_location, Anno)).
 
-get_end_location(Anno) -> get_anno(end_location, Anno).
-
-set_end_location(EndLine, Anno) -> put_anno(end_location, EndLine, Anno).
-
 get_inner_line(Anno) ->
     element(1, get_anno(inner_location, Anno, get_anno(location, Anno))).
 
@@ -325,3 +320,6 @@ end_location([$\n | String], Line, _Column) ->
     end_location(String, Line + 1, 1);
 end_location([_ | String], Line, Column) ->
     end_location(String, Line, Column + 1).
+
+range_anno(First, Last) ->
+    put_anno(end_location, get_anno(end_location, Last), First).

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -575,6 +575,19 @@ list(Config) when is_list(Config) ->
         "    end,\n"
         "    3\n"
         "]\n"
+    ),
+    ?assertFormat(
+        "[ 1\n"
+        ", 2\n"
+        "\n"
+        ", 3\n"
+        "]\n",
+        "[\n"
+        "    1,\n"
+        "    2,\n"
+        "\n"
+        "    3\n"
+        "]\n"
     ).
 
 binary(Config) when is_list(Config) ->
@@ -1778,7 +1791,10 @@ exportimport(Config) when is_list(Config) ->
         "%% comment\n"
         "-export([drop/4]).\n"
         "%% Another comment\n"
-        "-export([a/1, b/1]).\n",
+        "-export([\n"
+        "    a/1,\n"
+        "    b/1\n"
+        "]).\n",
         80
     ),
     ?assertFormat(
@@ -1793,7 +1809,10 @@ exportimport(Config) when is_list(Config) ->
         "-export([drop/4]).\n"
         "\n"
         "%% Another comment\n"
-        "-export([a/1, b/1]).\n",
+        "-export([\n"
+        "    a/1,\n"
+        "    b/1\n"
+        "]).\n",
         80
     ),
     ?assertSame(

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -714,6 +714,26 @@ record_create(Config) when is_list(Config) ->
         "    ]\n"
         "}\n",
         20
+    ),
+    ?assertSame(
+        "#foo{\n"
+        "    a = 1,\n"
+        "    b = 1,\n"
+        "\n"
+        "    c = 2\n"
+        "}\n",
+        15
+    ),
+    ?assertSame(
+        "#foo{\n"
+        "    a = 1,\n"
+        "\n"
+        "    % comment\n"
+        "    b = 2,\n"
+        "    % a non splitting comment\n"
+        "    c = 3\n"
+        "}\n",
+        15
     ).
 
 record_update(Config) when is_list(Config) ->
@@ -1775,6 +1795,28 @@ exportimport(Config) when is_list(Config) ->
         "%% Another comment\n"
         "-export([a/1, b/1]).\n",
         80
+    ),
+    ?assertSame(
+        "-export([\n"
+        "    % comment\n"
+        "    a/2,\n"
+        "\n"
+        "    % another group\n"
+        "    b/1\n"
+        "]).\n"
+    ),
+    ?assertSame(
+        "-export([\n"
+        "    a/2,\n"
+        "    c/2,\n"
+        "\n"
+        "    a/1,\n"
+        "    c/1,\n"
+        "\n"
+        "    b/1,\n"
+        "    d/2\n"
+        "    % trailing comment\n"
+        "]).\n"
     ).
 
 record_definition(Config) when is_list(Config) ->

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1817,6 +1817,16 @@ exportimport(Config) when is_list(Config) ->
         "    d/2\n"
         "    % trailing comment\n"
         "]).\n"
+    ),
+    ?assertSame(
+        "-import(erlfmt_algebra, [\n"
+        "    a/1,\n"
+        "    a/2,\n"
+        "    b/1,\n"
+        "    b/2,\n"
+        "    c/1,\n"
+        "    c/2\n"
+        "]).\n"
     ).
 
 record_definition(Config) when is_list(Config) ->


### PR DESCRIPTION
Fixes #72

This preserves empty lines between values in containers, like exports and records.

This required some refactoring, since the simple fold_doc now needed to not only be aware of the break, but also needed to have the original value, to be able to check for empty lines to preserve.

Really struggled to make this refactoring more readable and I guess it is debatable, whether I achieved that, so looking forward to ideas in the review.

Also needed to preserve the end line for better empty line detection.
Should probably do the same for inner end line, so maybe we can think of a better function name.