### PR TITLE
an example of formatting a dslish list with grouping

### DIFF
--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -588,6 +588,31 @@ list(Config) when is_list(Config) ->
         "\n"
         "    3\n"
         "]\n"
+    ),
+    ?assertFormat(
+        "gen_part_decode_funcs({constructed,bif}, TypeName, {_Name,parts,Tag,_Type}) ->\n"
+        "   emit([\n"
+        "       [\"  case Data of\",nl],\n"
+        "       [\"    L when is_list(L) ->\",nl],\n"
+        "       [\"      'dec_\",TypeName,\"'(lists:map(fun(X) -> element(1, \"],\n"
+        "       [{call,ber,ber_decode_erlang,[\"X\"]},\") end, L),\",{asis,Tag},\");\",nl],\n"
+        "       [\"    _ ->\",nl],\n"
+        "       [\"      [Res] = 'dec_\",TypeName,\"'([Data],\",{asis,Tag},\"),\",nl],\n"
+        "       [\"      Res\",nl],\n"
+        "       [\"  end\"]\n"
+        "   ]).\n",
+        "gen_part_decode_funcs({constructed, bif}, TypeName, {_Name, parts, Tag, _Type}) ->\n"
+        "    emit([\n"
+        "        [\"  case Data of\", nl],\n"
+        "        [\"    L when is_list(L) ->\", nl],\n"
+        "        [\"      'dec_\", TypeName, \"'(lists:map(fun(X) -> element(1, \"],\n"
+        "        [{call, ber, ber_decode_erlang, [\"X\"]}, \") end, L),\", {asis, Tag}, \");\", nl],\n"
+        "        [\"    _ ->\", nl],\n"
+        "        [\"      [Res] = 'dec_\", TypeName, \"'([Data],\", {asis, Tag}, \"),\", nl],\n"
+        "        [\"      Res\", nl],\n"
+        "        [\"  end\"]\n"
+        "    ]).\n",
+        92
     ).
 
 binary(Config) when is_list(Config) ->


### PR DESCRIPTION
This pull request is just to facilitate a discussion.

I was busy writing up the formatting decision for issue #19 that we want to add an option to add a comment before a form, that opts it out of formatting, but then I thought about this idea.
Maybe there is still a way to avoid adding this option, as we want to keep options to a minimum.
Is it possible ask users to group their lists, using lists?
Since then you can still get a reasonably formatted DSLish list.
See here the formatted DSLish list, with the intended lines, grouped in lists:

```erlang
gen_part_decode_funcs({constructed, bif}, TypeName, {_Name, parts, Tag, _Type}) ->
    emit([
        ["  case Data of", nl],
        ["    L when is_list(L) ->", nl],
        ["      'dec_", TypeName, "'(lists:map(fun(X) -> element(1, "],
        [{call, ber, ber_decode_erlang, ["X"]}, ") end, L),", {asis, Tag}, ");", nl],
        ["    _ ->", nl],
        ["      [Res] = 'dec_", TypeName, "'([Data],", {asis, Tag}, "),", nl],
        ["      Res", nl],
        ["  end"]
    ]).
```