### PR TITLE
Use deterministic compiler option for releasing precompiled escript

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
 {profiles, [
     {release, [
         {deps, [getopt]},
-        {erl_opts, [no_debug_info]}
+        {erl_opts, [no_debug_info, deterministic]}
     ]},
     {test, [
         {deps, [getopt]}


### PR DESCRIPTION
This removes user's CWD from the file debug info and in consequence from stacktraces.
We don't need this in production releases.