### PR TITLE
erlfmt erlfmt and keep it that way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Release
       run: rebar3 as release escriptize
     - name: Check foramtting
-      run: _build/release/bin/erlfmt --check "{src,include,test}/*.{hrl,erl}" "rebar.config"
+      run: rm src/erlfmt_parse.erl && _build/release/bin/erlfmt --check "{src,include,test}/*.{hrl,erl}" "rebar.config"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,7 @@ jobs:
       run: rebar3 ct
     - name: Run Dialyzer
       run: rebar3 dialyzer
+    - name: Release
+      run: rebar3 as release escriptize
+    - name: Check foramtting
+      run: _build/release/bin/erlfmt --check "{src,include,test}/*.{hrl,erl}" "rebar.config"

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -77,8 +77,10 @@ format_file(FileName, Out, Options) ->
                 [$\n | Formatted] = format_nodes(NodesWithPragma, Width),
                 verify_nodes(FileName, NodesWithPragma, Formatted),
                 case write_formatted(FileName, Formatted, Out) of
-                    {check_failed, OriginalBin, FormattedBin} -> {check_failed, OriginalBin, FormattedBin, Warnings};
-                    ok -> {ok, Warnings}
+                    {check_failed, OriginalBin, FormattedBin} ->
+                        {check_failed, OriginalBin, FormattedBin, Warnings};
+                    ok ->
+                        {ok, Warnings}
                 end;
             {skip, RawString} ->
                 write_formatted(FileName, RawString, Out),

--- a/src/erlfmt_cli.erl
+++ b/src/erlfmt_cli.erl
@@ -33,8 +33,7 @@ opts() ->
         {check, $c, "check", undefined,
             "Check if your files are formatted."
             "Get exit code 1, if some files are not formatted."
-            "stdin is not supported and --write is not supported."
-        },
+            "stdin is not supported and --write is not supported."},
         {print_width, undefined, "print-width", integer,
             "The line length that formatter would wrap on"},
         {require_pragma, undefined, "require-pragma", undefined,
@@ -66,11 +65,17 @@ do_unprotected(Opts, Name) ->
                 _ -> ok
             end,
             case parallel(fun(File) -> format_file(File, Config) end, Files) of
-                ok -> ok;
+                ok ->
+                    ok;
                 warn ->
-                    io:format(standard_error, "[warn] Code style issues found in the above file(s). Forgot to run erlfmt?~n", []),
+                    io:format(
+                        standard_error,
+                        "[warn] Code style issues found in the above file(s). Forgot to run erlfmt?~n",
+                        []
+                    ),
                     erlang:halt(1);
-                error -> erlang:halt(4)
+                error ->
+                    erlang:halt(4)
             end;
         {error, Message} ->
             io:put_chars(standard_error, [Message, "\n\n"]),
@@ -181,7 +186,8 @@ parallel_loop(Fun, [Elem | Rest], N, Refs, ReducedResult) when length(Refs) < N 
 parallel_loop(Fun, List, N, Refs0, ReducedResult0) ->
     receive
         {'DOWN', Ref, process, _, Result} when
-                Result =:= error; Result =:= warn; Result =:= ok; Result =:= skip ->
+            Result =:= error; Result =:= warn; Result =:= ok; Result =:= skip
+        ->
             Refs = Refs0 -- [Ref],
             ReducedResult =
                 case {Result, ReducedResult0} of

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -658,11 +658,12 @@ clause_to_algebra({spec_clause, _Meta, Head, [Body], Guards}) ->
 
 spec_clause_gaurds_to_algebra(Expr) ->
     Meta = element(2, Expr),
-    Doc = case Expr of
-        {guard_or, _Meta, Guards} -> spec_guard_to_algebra(Guards, <<";">>);
-        {guard_and, _Meta, Guards} -> spec_guard_to_algebra(Guards, <<",">>);
-        Other -> do_expr_to_algebra(Other)
-    end,
+    Doc =
+        case Expr of
+            {guard_or, _Meta, Guards} -> spec_guard_to_algebra(Guards, <<";">>);
+            {guard_and, _Meta, Guards} -> spec_guard_to_algebra(Guards, <<",">>);
+            Other -> do_expr_to_algebra(Other)
+        end,
     combine_comments(Meta, maybe_wrap_in_parens(Meta, Doc)).
 
 spec_guard_to_algebra(Guards, Separator) ->
@@ -733,8 +734,11 @@ has_inner_break(Outer, Inner) ->
 is_next_break_fits_op(Op) ->
     lists:member(Op, ?NEXT_BREAK_FITS_OPS).
 
-is_next_break_fits({FlexContainer, Meta, Values} = Expr) when FlexContainer =:= tuple; FlexContainer =:= bin ->
-    (has_opening_line_break(Meta, Values) orelse has_trailing_comments(Values)) andalso has_no_comments_or_parens(Expr);
+is_next_break_fits({FlexContainer, Meta, Values} = Expr) when
+    FlexContainer =:= tuple; FlexContainer =:= bin
+->
+    (has_opening_line_break(Meta, Values) orelse has_trailing_comments(Values)) andalso
+        has_no_comments_or_parens(Expr);
 is_next_break_fits(Expr) ->
     lists:member(element(1, Expr), ?NEXT_BREAK_FITS) andalso has_no_comments_or_parens(Expr).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1108,7 +1108,7 @@ list_comprehension(Config) when is_list(Config) ->
         "    || ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)\n"
         "])\n"
     ),
-        ?assertSame(
+    ?assertSame(
         "[\n"
         "    a\n"
         "    || {a, b} <- es\n"
@@ -1121,7 +1121,8 @@ list_comprehension(Config) when is_list(Config) ->
         "       filter(b)\n"
         "]\n"
     ),
-    ?assertFormat("string:equal([Value || {string, _, Value} <- ValuesL], [Value || {string, _, Value} <- ValuesR]).\n",
+    ?assertFormat(
+        "string:equal([Value || {string, _, Value} <- ValuesL], [Value || {string, _, Value} <- ValuesR]).\n",
         "string:equal([Value || {string, _, Value} <- ValuesL], [\n"
         "    Value\n"
         "    || {string, _, Value} <- ValuesR\n"
@@ -1136,7 +1137,8 @@ binary_comprehension(Config) when is_list(Config) ->
         "    X\n"
         "    || <<X, Y>> <= Results,\n"
         "       X >= Y\n"
-        ">>\n"),
+        ">>\n"
+    ),
     ?assertFormat(
         "<<(Long + Expression) || X <- Y, X < 10>>",
         "<<\n"


### PR DESCRIPTION
Fixes #12 

Before formatting I only ran this task and got the following output
https://github.com/WhatsApp/erlfmt/runs/1066854528?check_suite_focus=true

![Screen Shot 2020-09-03 at 2 37 05 PM](https://user-images.githubusercontent.com/1829933/92122193-0e3dfa00-edf3-11ea-893a-0bb124c8d104.png)

After formatting, checks pass

I had to include removing the generated parser, as this is not committed into the repo and not formatted on generation, so we probably should not check it.
