### PR TITLE
rather use format_string for checking

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -17,7 +17,7 @@
 -export([
     main/1,
     init/1,
-    format_file/3,
+    format_file/2,
     format_string/2,
     format_range/4,
     read_nodes/1,
@@ -58,11 +58,9 @@ init(State) ->
     rebar3_fmt_prv:init(State).
 
 %% API entry point
--spec format_file(file:name_all() | stdin, out(), config()) ->
-    {ok, [error_info()]} |
-    skip |
-    {error, error_info()}.
-format_file(FileName, Out, Options) ->
+-spec format_file(file:name_all() | stdin, config()) ->
+    {ok, [unicode:chardata()], [error_info()]} | {skip, string()} | {error, error_info()}.
+format_file(FileName, Options) ->
     Width = proplists:get_value(width, Options, ?DEFAULT_WIDTH),
     Pragma = proplists:get_value(pragma, Options, ignore),
     try
@@ -75,18 +73,16 @@ format_file(FileName, Out, Options) ->
                     end,
                 Formatted = format_nodes(NodesWithPragma, Width),
                 verify_nodes(FileName, NodesWithPragma, Formatted),
-                write_formatted(FileName, Formatted, Out),
-                {ok, Warnings};
+                {ok, Formatted, Warnings};
             {skip, RawString} ->
-                write_formatted(FileName, RawString, Out),
-                skip
+                {skip, RawString}
         end
     catch
         {error, Error} -> {error, Error}
     end.
 
 -spec format_string(string(), config()) ->
-    {ok, string(), [error_info()]} | skip | {error, error_info()}.
+    {ok, string(), [error_info()]} | {skip, string()} | {error, error_info()}.
 format_string(String, Options) ->
     Width = proplists:get_value(width, Options, ?DEFAULT_WIDTH),
     Pragma = proplists:get_value(pragma, Options, ignore),
@@ -101,8 +97,8 @@ format_string(String, Options) ->
                 Formatted = format_nodes(NodesWithPragma, Width),
                 verify_nodes("nofile", NodesWithPragma, Formatted),
                 {ok, unicode:characters_to_list(Formatted), Warnings};
-            {skip, _} ->
-                skip
+            {skip, RawString} ->
+                {skip, RawString}
         end
     catch
         {error, Error} -> {error, Error}
@@ -287,6 +283,7 @@ node_string(Cont) ->
     {String, Anno} = erlfmt_scan:last_node_string(Cont),
     {raw_string, Anno, string:trim(String, both, "\n")}.
 
+-spec format_nodes([erlfmt_parse:abstract_form()], pos_integer()) -> [unicode:chardata()].
 format_nodes([], _PageWidth) ->
     [];
 format_nodes(Nodes, PageWidth) ->
@@ -342,6 +339,7 @@ maybe_empty_line(Node, Next) ->
         false -> ""
     end.
 
+-spec format_node(erlfmt_parse:abstract_form(), pos_integer()) -> unicode:chardata().
 format_node({raw_string, _Anno, String}, _PageWidth) ->
     String;
 format_node({shebang, _Anno, String}, _PageWidth) ->
@@ -434,24 +432,6 @@ try_location([Node | _], _) when is_tuple(Node) -> erlfmt_scan:get_anno(location
 try_location(_, Node) when is_tuple(Node) -> erlfmt_scan:get_anno(location, Node);
 try_location(_, [Node | _]) when is_tuple(Node) -> erlfmt_scan:get_anno(location, Node);
 try_location(_, _) -> 0.
-
-write_formatted(_FileName, Formatted, standard_out) ->
-    io:put_chars(Formatted);
-write_formatted(FileName, Formatted, Out) ->
-    OutFileName = out_file(FileName, Out),
-    case filelib:ensure_dir(OutFileName) of
-        ok -> ok;
-        {error, Reason1} -> throw({error, {OutFileName, 0, file, Reason1}})
-    end,
-    case file:write_file(OutFileName, unicode:characters_to_binary(Formatted)) of
-        ok -> ok;
-        {error, Reason2} -> throw({error, {OutFileName, 0, file, Reason2}})
-    end.
-
-out_file(FileName, replace) ->
-    FileName;
-out_file(FileName, {path, Path}) ->
-    filename:join(Path, filename:basename(FileName)).
 
 -spec format_error_info(error_info()) -> unicode:chardata().
 format_error_info({FileName, Anno, Mod, Reason}) ->

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -26,10 +26,9 @@
     format_error_info/1
 ]).
 
--export_type([error_info/0, out/0, config/0, pragma/0]).
+-export_type([error_info/0, config/0, pragma/0]).
 
 -type error_info() :: {file:name_all(), erl_anno:location(), module(), Reason :: any()}.
--type out() :: standard_out | {path, file:name_all()} | replace.
 -type pragma() :: require | insert | ignore.
 -type config() :: [{pragma, pragma()} | {width, pos_integer()}].
 

--- a/src/erlfmt_cli.erl
+++ b/src/erlfmt_cli.erl
@@ -31,7 +31,7 @@ opts() ->
         {write, $w, "write", undefined, "modify formatted files in place"},
         {out, $o, "out", binary, "output directory"},
         {verbose, undefined, "verbose", undefined, "include debug output"},
-        {check, undefined, "check", undefined,
+        {check, $c, "check", undefined,
             "Check if your files are formatted."
             "Get exit code 1, if some files are not formatted."
             "--write is not supported."},

--- a/src/erlfmt_scan.erl
+++ b/src/erlfmt_scan.erl
@@ -136,6 +136,8 @@ continue(Scan, Inner0, Loc0, Buffer0) ->
 read_rest(#state{inner = undefined}) ->
     %% reached EOF, no further nodes
     {ok, ""};
+read_rest(#state{scan = _Scan, inner = eof, loc = _Loc, buffer = Buffer}) ->
+    {ok, stringify_tokens(Buffer)};
 read_rest(#state{scan = _Scan, inner = IO, loc = _Loc, buffer = Buffer}) ->
     String = stringify_tokens(Buffer),
     try


### PR DESCRIPTION
Changed --check to rather use format_string, this way stdin is also supported and API is simpler.

## Test Plan

```sh
$ rebar3 as release escriptize

$ _build/release/bin/erlfmt --check "{src,include,test}/*.{hrl,erl}" "rebar.config"
Checking formatting...
[warn] src/erlfmt_cli.erl
[warn] src/erlfmt_scan.erl
[warn] test/erlfmt_SUITE.erl
[warn] Code style issues found in the above file(s). Forgot to run erlfmt?

$ _build/release/bin/erlfmt -w "{src,include,test}/*.{hrl,erl}" "rebar.config"
$ git diff
...
modified:   src/erlfmt_cli.erl
modified:   src/erlfmt_scan.erl
modified:   test/erlfmt_SUITE.erl
...

$ _build/release/bin/erlfmt --check "{src,include,test}/*.{hrl,erl}" "rebar.config"
Checking formatting...
All matched files use erlfmt code style!
```