### PR TITLE
set minimum otp version in rebar config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,8 @@
 
 {escript_emu_args, "%%! +sbtu +A0 -noinput -noshell -mode minimal\n"}.
 
+{minimum_otp_vsn, "21"}.
+
 {erlc_compiler, [{recursive, false}]}.
 
 {provider_hooks, [


### PR DESCRIPTION
As suggested by @paulo-ferraz-oliveira https://github.com/WhatsApp/erlfmt/issues/178#issuecomment-696976024