### PR TITLE
Update instructions for integration with rebar and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ can be configured with defaults in your `rebar.config`, for example:
 
 ```erlang formatted rebarconfig2
 {erlfmt, [
-    write,
     {files, "{src,include,test}/*.{hrl,erl}"}
 ]}.
 ```
@@ -81,7 +80,13 @@ can be configured with defaults in your `rebar.config`, for example:
 Now you can format all the files in your project by running:
 
 ```
-$ rebar3 fmt
+$ rebar3 fmt --write
+```
+
+And you can add the following command in your CI to ensure your Erlang is formatted:
+
+```
+$ rebar3 fmt --check
 ```
 
 ### Escript

--- a/src/rebar3_fmt_prv.erl
+++ b/src/rebar3_fmt_prv.erl
@@ -28,7 +28,7 @@ init(State) ->
             {module, ?MODULE},
             {bare, true},
             {deps, ?DEPS},
-            {example, "rebar3 fmt"},
+            {example, "rebar3 fmt --write"},
             {opts, erlfmt_cli:opts()},
             {short_desc, "Erlang code formatter"},
             {desc, "Erlang code formatter"}


### PR DESCRIPTION
With the old recommendation of rebar config, it was difficult (impossible?) to run `rebar3 fmt --check` in CI and have it check formatting.

This PR changes the recommended setup so that the command users must run in order to format things is `rebar3 fmt --write`, not just `rebar3 fmt`. Then they can do `rebar3 fmt --check` in CI.

I probably have not thought through all the implications or updated all the places that need to be updated, so please consider this a "discussion" PR.