### PR TITLE
parse attributes with empty parens

### DIFF
--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -182,6 +182,7 @@ bin_element_type -> var ':' var '*' type :
 attr_val -> expr                     : [delete_parens('$1')].
 attr_val -> expr ',' exprs           : ['$1' | '$3'].
 attr_val -> '(' expr ',' exprs ')'   : ['$2' | '$4'].
+attr_val -> '(' ')'                  : [].
 
 %% Anno is wrong here, we'll adjust it at the top level using the dot token.
 function -> function_clauses :

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -57,6 +57,7 @@
     function/1,
     attribute/1,
     exportimport/1,
+    ifdef/1,
     record_definition/1,
     spec/1,
     define/1,
@@ -108,6 +109,7 @@ groups() ->
             function,
             attribute,
             exportimport,
+            ifdef,
             spec,
             record_definition,
             define,
@@ -2040,7 +2042,9 @@ exportimport(Config) when is_list(Config) ->
         "    c/1,\n"
         "    c/2\n"
         "]).\n"
-    ),
+    ).
+
+ifdef(Config) when is_list(Config) ->
     %% preserves empty line after if, ifdef, ifndef, else
     ?assertSame(
         "-if(true).\n"
@@ -2081,6 +2085,16 @@ exportimport(Config) when is_list(Config) ->
         "\n"
         "ok() -> ok.\n"
         "\n"
+        "-endif.\n"
+    ),
+    %% preserves no empty line before endif
+    ?assertSame(
+        "-ifdef(TEST).\n"
+        "start(_StartType, _StartArgs) ->\n"
+        "    mylib_sup:start_link().\n"
+        "\n"
+        "stop(_State) ->\n"
+        "    ok.\n"
         "-endif.\n"
     ).
 


### PR DESCRIPTION
Fixes #178

attributes can have zero parameters, for example:
```erlang
-endif().
```

For more details on how this was discovered, see the issue