### PR TITLE
parse attributes with empty parens

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -53,7 +53,7 @@
 to_algebra({function, Meta, Clauses}) ->
     Doc = concat(clauses_to_algebra(Clauses), string(".")),
     combine_comments(Meta, Doc);
-to_algebra({attribute, Meta, Name, []}) ->
+to_algebra({attribute, Meta, Name, no_parens}) ->
     Doc = concat(<<"-">>, expr_to_algebra(Name), <<".">>),
     combine_comments(Meta, Doc);
 to_algebra({attribute, Meta, {atom, _, define}, [Define, empty]}) ->

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -97,7 +97,7 @@ node -> standalone_exprs anno_exprs : {exprs, ?range_anno('$1', '$2'), ?val('$2'
 
 %% Anno is wrong here, we'll adjust it at the top level using the dot token.
 attribute -> '-' 'if' attr_val               : build_attribute('$1', '$2', '$3').
-attribute -> '-' atom                        : build_attribute('$1', '$2', []).
+attribute -> '-' atom                        : build_attribute('$1', '$2', no_parens).
 attribute -> '-' atom attr_val               : build_attribute('$1', '$2', '$3').
 attribute -> '-' spec type_spec              : build_attribute('$1', '$2', ['$3']).
 attribute -> '-' callback type_spec          : build_attribute('$1', '$2', ['$3']).
@@ -182,6 +182,7 @@ bin_element_type -> var ':' var '*' type :
 attr_val -> expr                     : [delete_parens('$1')].
 attr_val -> expr ',' exprs           : ['$1' | '$3'].
 attr_val -> '(' expr ',' exprs ')'   : ['$2' | '$4'].
+attr_val -> '(' ')'                  : [].
 
 %% Anno is wrong here, we'll adjust it at the top level using the dot token.
 function -> function_clauses :

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -224,11 +224,15 @@ attributes(Config) when is_list(Config) ->
         parse_form("-if(?foo == 2).")
     ),
     ?assertMatch(
-        {attribute, _, {atom, _, else}, []},
+        {attribute, _, {atom, _, else}, no_parens},
         parse_form("-else.")
     ),
     ?assertMatch(
-        {attribute, _, {atom, _, endif}, []},
+        {attribute, _, {atom, _, else}, []},
+        parse_form("-else().")
+    ),
+    ?assertMatch(
+        {attribute, _, {atom, _, endif}, no_parens},
         parse_form("-endif.")
     ),
     ?assertMatch(

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -57,6 +57,7 @@
     function/1,
     attribute/1,
     exportimport/1,
+    ifdef/1,
     record_definition/1,
     spec/1,
     define/1,
@@ -108,6 +109,7 @@ groups() ->
             function,
             attribute,
             exportimport,
+            ifdef,
             spec,
             record_definition,
             define,
@@ -2040,7 +2042,9 @@ exportimport(Config) when is_list(Config) ->
         "    c/1,\n"
         "    c/2\n"
         "]).\n"
-    ),
+    ).
+
+ifdef(Config) when is_list(Config) ->
     %% preserves empty line after if, ifdef, ifndef, else
     ?assertSame(
         "-if(true).\n"
@@ -2082,6 +2086,16 @@ exportimport(Config) when is_list(Config) ->
         "ok() -> ok.\n"
         "\n"
         "-endif.\n"
+    ),
+    %% preserves no empty line before endif
+    ?assertSame(
+        "-ifdef(TEST).\n"
+        "start(_StartType, _StartArgs) ->\n"
+        "    mylib_sup:start_link().\n"
+        "\n"
+        "stop(_State) ->\n"
+        "    ok.\n"
+        "-endif().\n"
     ).
 
 record_definition(Config) when is_list(Config) ->


### PR DESCRIPTION
Fixes #178

attributes can have zero parameters, for example:
```erlang
-endif().
```

For more details on how this was discovered, see the issue