### PR TITLE
fix crash with comments in catch

### DIFF
--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -228,6 +228,11 @@ insert_nested({'receive', Meta, Clauses0, AfterExpr0, AfterBody0}, Comments0) ->
 insert_nested({'if', Meta, Clauses0}, Comments0) ->
     Clauses = insert_expr_container(Clauses0, Comments0),
     {{'if', Meta, Clauses}, []};
+insert_nested({'try', Meta, Exprs0, OfClauses0, CatchClauses0, []}, Comments0) ->
+    {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
+    {OfClauses, Comments2} = insert_expr_list(OfClauses0, Comments1),
+    CatchClauses = insert_expr_container(CatchClauses0, Comments2),
+    {{'try', Meta, Exprs, OfClauses, CatchClauses, []}, []};
 insert_nested({'try', Meta, Exprs0, OfClauses0, CatchClauses0, After0}, Comments0) ->
     {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
     {OfClauses, Comments2} = insert_expr_list(OfClauses0, Comments1),

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1737,6 +1737,15 @@ try_expression(Config) when is_list(Config) ->
         "end\n",
         35
     ),
+    ?assertSame(
+        "try 2 of\n"
+        "    true -> ok\n"
+        "catch\n"
+        "    _ ->\n"
+        "        []\n"
+        "    %% comment\n"
+        "end\n"
+    ),
     ?assertFormat(
         "try Expr of _ -> ok after Expr end",
         "try Expr of\n"


### PR DESCRIPTION
This does not fix #125 , but it stops it from crashing at least.