### PR TITLE
better rebar3 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ And you can add the following command in your CI to ensure your Erlang is format
 $ rebar3 fmt --check
 ```
 
-For more usage instructions, see [./doc/RebarUsage.md]
+For more usage instructions, see (RebarUsage)[./doc/RebarUsage.md]
 
 ### Escript
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ can be configured with defaults in your `rebar.config`, for example:
 
 ```erlang formatted rebarconfig2
 {erlfmt, [
+    write,
     {files, "{src,include,test}/*.{hrl,erl}"}
 ]}.
 ```
@@ -80,7 +81,7 @@ can be configured with defaults in your `rebar.config`, for example:
 Now you can format all the files in your project by running:
 
 ```
-$ rebar3 fmt --write
+$ rebar3 fmt
 ```
 
 And you can add the following command in your CI to ensure your Erlang is formatted:
@@ -88,6 +89,8 @@ And you can add the following command in your CI to ensure your Erlang is format
 ```
 $ rebar3 fmt --check
 ```
+
+For more usage instructions, see [./doc/RebarUsage.md]
 
 ### Escript
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ And you can add the following command in your CI to ensure your Erlang is format
 $ rebar3 fmt --check
 ```
 
-For more usage instructions, see (RebarUsage)[./doc/RebarUsage.md]
+For more usage instructions, see [RebarUsage](./doc/RebarUsage.md)
 
 ### Escript
 

--- a/doc/RebarUsage.md
+++ b/doc/RebarUsage.md
@@ -1,0 +1,65 @@
+## Using erlfmt with Rebar
+
+The easiest way to use erlfmt is as a rebar plugin, by adding to your
+`rebar.config`:
+
+```erlang formatted rebarconfig1
+{project_plugins, [erlfmt]}.
+```
+
+This will provide a new `rebar3 fmt` task.
+All erlfmt command-line options can be configured with defaults in your `rebar.config`, for example:
+
+```erlang formatted rebarconfig2
+{erlfmt, [
+    write,
+    {files, "{src,include,test}/*.{hrl,erl}"}
+]}.
+```
+
+Now you can format all the files in your project by running:
+
+```sh
+$ rebar3 fmt
+```
+
+And you can add the following command in your CI to ensure your Erlang is formatted:
+
+```sh
+$ rebar3 fmt --check
+```
+
+This means that `--check` overwrites `--write`.
+
+The options specified in the `rebar.config` file can all be overwritten using command line arguments.
+
+For example, if you want to format in place as specified in the `rebar.config` with the `write` option,
+but only format a single file, then you can overwrite the file list:
+
+```sh
+$ rebar3 fmt ./src/myfile.erl
+```
+
+You could also setup your rebar3 config to:
+  - only format files that include a `%% @format` comment, using `require_pragma`,
+  - only check files and not format them, using `check` instead of `write`,
+  - output which files are being checked, using `verbose` and
+  - set the default width, using `{print_width, 100}`
+
+```erlang formatted rebarconfig3
+{erlfmt, [
+    check,
+    require_pragma,
+    verbose,
+    {print_width, 100},
+    {files, ["{src,include,test}/*.{hrl,erl,app.src}", "rebar.config"]}
+]}.
+```
+
+See the command line help for a complete list of options:
+```sh
+$ rebar3 --help
+```
+Simply convert dashes to underscores as appropriate,
+for example `--insert-pragma`, becomes `insert_pragma`.
+

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -43,9 +43,9 @@ main(Argv) ->
     Opts = erlfmt_cli:opts(),
     case getopt:parse(Opts, Argv) of
         {ok, {ArgOpts, []}} ->
-            erlfmt_cli:do(ArgOpts, "erlfmt");
+            erlfmt_cli:do("erlfmt", ArgOpts);
         {ok, {ArgOpts, ExtraFiles}} ->
-            erlfmt_cli:do([{files, ExtraFiles} | ArgOpts], "erlfmt");
+            erlfmt_cli:do("erlfmt", [{files, ExtraFiles} | ArgOpts]);
         {error, Error} ->
             io:put_chars(standard_error, [getopt:format_error(Opts, Error), "\n\n"]),
             getopt:usage(Opts, "erlfmt")

--- a/src/erlfmt_cli.erl
+++ b/src/erlfmt_cli.erl
@@ -262,7 +262,9 @@ parse_opts([], Files, Config) ->
     case lists:member(stdin, Files) of
         true -> {error, "stdin mode can't be combined with other files"};
         false -> {format, lists:reverse(Files), Config}
-    end.
+    end;
+parse_opts([Unknown | _], _Files, _Config) ->
+    {error, io_lib:format("unknown option: ~p", [Unknown])}.
 
 -spec resolve_parsed(parsed(), parsed()) -> parsed().
 resolve_parsed(PreferParsed, DefaultParsed) ->

--- a/src/rebar3_fmt_prv.erl
+++ b/src/rebar3_fmt_prv.erl
@@ -40,9 +40,9 @@ do(State) ->
     ConfigOpts = rebar_state:get(State, erlfmt, []),
     case rebar_state:command_parsed_args(State) of
         {ArgOpts, []} ->
-            erlfmt_cli:do(ConfigOpts ++ ArgOpts, "rebar3 fmt");
+            erlfmt_cli:do("rebar3 fmt", ArgOpts, ConfigOpts);
         {ArgOpts, ExtraFiles} ->
-            erlfmt_cli:do(ConfigOpts ++ [{files, ExtraFiles}] ++ ArgOpts, "rebar3 fmt")
+            erlfmt_cli:do("rebar3 fmt", ArgOpts, ConfigOpts ++ [{files, ExtraFiles}])
     end,
     {ok, State}.
 


### PR DESCRIPTION
This gives command line arguments preference over arguments specified in the rebar3 config.

This Fixes #177
And fixes #141

## Test Plan:

Given the following config

```erlang
{erlfmt, [
    write,
    {files, "{src,include,test}/*.{hrl,erl}"}
]}.
```

```sh
rebar3 fmt # formats all files in place
rebar3 fmt ./src/example.app.src # only formats the single file
rebar3 fmt --check # checks all files and doesn't format
rebar3 fmt -o ./out/ # outputs formatted files folder and doesn't format the original
rebar3 fmt -o out src/*.erl # formats only selected files and outputs them to selected folder
```

### Tested with incorrect config

```
{erlfmt, [
    check,
    require_pragma,
    verbose,
    {width, 100},
    {files, ["{src,include,test}/*.{hrl,erl,app.src}", "rebar.config"]}
]}.
```

Got error:
```
unknown option: {width,100}

Usage: rebar3 fmt [-h] [-v] [-w] [-o <out>] [--verbose] [-c]
                  [--print-width <print_width>] [--require-pragma]
                  [--insert-pragma] [<files>]
```