### PR TITLE
Recommend to use project_plugins instead of plugins in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The easiest way to use erlfmt is as a rebar plugin, by adding to your
 `rebar.config`:
 
 ```erlang formatted rebarconfig1
-{plugins, [erlfmt]}.
+{project_plugins, [erlfmt]}.
 ```
 
 This will provide a new `rebar3 fmt` task. All erlfmt command-line options


### PR DESCRIPTION
plugins are also downloaded if the project is a transitive dependency,
project_plugins are downloaded only when working directly on the codebase.
For the tasks erlfmt is used for normally, project_plugins seems more
appropriate