### PR TITLE
consistent binary operator breaking

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -307,13 +307,15 @@ format_nodes_loop(
 ) when Name =:= 'if'; Name =:= 'ifdef'; Name =:= 'ifndef'; Name =:= 'else' ->
     % preserve empty line after
     [$\n, format_node(Attr, PageWidth)] ++
-        maybe_empty_line(Attr, NextNode) ++ format_nodes_loop(Rest, PageWidth);
+        maybe_empty_line(Attr, NextNode) ++
+        format_nodes_loop(Rest, PageWidth);
 format_nodes_loop([Node | [{attribute, _, {atom, _, Name}, _} = Attr | _] = Rest], PageWidth) when
     Name =:= 'else'; Name =:= 'endif'
 ->
     % preserve empty line before
     [$\n, format_node(Node, PageWidth)] ++
-        maybe_empty_line(Node, Attr) ++ format_nodes_loop(Rest, PageWidth);
+        maybe_empty_line(Node, Attr) ++
+        format_nodes_loop(Rest, PageWidth);
 format_nodes_loop([{attribute, _, {atom, _, RepeatedName}, _} | _] = Nodes, PageWidth) ->
     {Attrs, Rest} = split_attrs(RepeatedName, Nodes),
     MaybeEmptyLine =
@@ -409,7 +411,9 @@ equivalent({Type, _, L1, L2, L3}, {Type, _, R1, R2, R3}) ->
     equivalent(L1, R1) andalso equivalent(L2, R2) andalso equivalent(L3, R3);
 equivalent({Type, _, L1, L2, L3, L4}, {Type, _, R1, R2, R3, R4}) ->
     equivalent(L1, R1) andalso
-        equivalent(L2, R2) andalso equivalent(L3, R3) andalso equivalent(L4, R4);
+        equivalent(L2, R2) andalso
+        equivalent(L3, R3) andalso
+        equivalent(L4, R4);
 equivalent(Ls, Rs) when is_list(Ls), is_list(Rs) ->
     equivalent_list(Ls, Rs);
 equivalent(L, R) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -312,8 +312,10 @@ binary_op_to_algebra(Op, Meta, Left, Right, HasBreak, Indent) ->
     RightD = binary_operand_to_algebra(Op, Right, HasBreak, 0),
     Doc =
         case is_next_break_fits_op(Op) of
-            true -> binary_op_to_algebra(Op, Left, Right, LeftD, RightD, HasBreak, Indent);
-            false -> breakable_binary_op_to_algebra(Op, Left, Right, LeftD, RightD, HasBreak, Indent)
+            true ->
+                binary_op_to_algebra(Op, Left, Right, LeftD, RightD, HasBreak, Indent);
+            false ->
+                breakable_binary_op_to_algebra(Op, Left, Right, LeftD, RightD, HasBreak, Indent)
         end,
     combine_comments(Meta, maybe_wrap_in_parens(Meta, Doc)).
 
@@ -379,7 +381,6 @@ binary_operand_to_algebra(Op, {op, Meta, Op, Left, Right} = Expr, HasBreak, Inde
             binary_op_to_algebra(Op, Meta, Left, Right, HasBreak, Indent);
         _ ->
             expr_to_algebra(Expr)
-            % binary_op_to_algebra(Op, Meta, Left, Right, binary_op_has_any_break(Op, Left, Right), ?INDENT)
     end;
 binary_operand_to_algebra(_ParentOp, Expr, _HasBreak, _Indent) ->
     expr_to_algebra(Expr).

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1064,7 +1064,11 @@ smoke_test_stdio_check(Config) when is_list(Config) ->
     DataDir = ?config(data_dir, Config),
     Same = os:cmd(
         "cat " ++
-            filename:join(DataDir, "attributes.erl") ++ " | " ++ escript() ++ " - " ++ "--check"
+            filename:join(DataDir, "attributes.erl") ++
+            " | " ++
+            escript() ++
+            " - " ++
+            "--check"
     ),
     ?assertMatch(nomatch, string:find(Same, "[warn]")),
     Warn = os:cmd(
@@ -1074,7 +1078,10 @@ smoke_test_stdio_check(Config) when is_list(Config) ->
     Skip = os:cmd(
         "cat " ++
             filename:join(DataDir, "comments.erl") ++
-            " | " ++ escript() ++ " - " ++ "--check --require-pragma --verbose"
+            " | " ++
+            escript() ++
+            " - " ++
+            "--check --require-pragma --verbose"
     ),
     ?assertNotMatch(nomatch, string:find(Skip, "Skip")).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -537,8 +537,8 @@ binary_operator(Config) when is_list(Config) ->
         "        C == $\/\n"
         "->\n"
         "    ok.\n"
-     ),
-     ?assertSame(
+    ),
+    ?assertSame(
         "[\n"
         "    Slash ++\n"
         "        binary_to_list(A2) ++\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -307,7 +307,8 @@ binary_operator(Config) when is_list(Config) ->
     ?assertFormat(
         "Foo ++ Bar ++ Baz",
         "Foo ++\n"
-        "    Bar ++ Baz\n",
+        "    Bar ++\n"
+        "    Baz\n",
         15
     ),
     ?assertFormat(
@@ -335,7 +336,8 @@ binary_operator(Config) when is_list(Config) ->
     ?assertSame("Foo + Bar + Baz\n"),
     ?assertFormat(
         "Foo + Bar + Baz",
-        "Foo + Bar +\n"
+        "Foo +\n"
+        "    Bar +\n"
         "    Baz\n",
         14
     ),
@@ -378,19 +380,22 @@ binary_operator(Config) when is_list(Config) ->
     ),
     ?assertFormat(
         "A * (B + C) * D",
-        "A * (B + C) *\n"
+        "A *\n"
+        "    (B + C) *\n"
         "    D\n",
         12
     ),
     ?assertFormat(
         "One * (Two + Three + Four) * Five",
         "One *\n"
-        "    (Two + Three +\n"
-        "        Four) * Five\n",
+        "    (Two +\n"
+        "        Three +\n"
+        "        Four) *\n"
+        "    Five\n",
         20
     ),
 
-    %% Next break fits
+    % %% Next break fits
     ?assertSame(
         "Foo = [\n"
         "    1\n"
@@ -492,6 +497,57 @@ binary_operator(Config) when is_list(Config) ->
         "Foo andalso\n"
         "    Bar andalso\n"
         "    Baz\n"
+    ),
+    ?assertFormat(
+        "Foo orelse Bar orelse Baz\n",
+        "Foo orelse\n"
+        "    Bar orelse\n"
+        "    Baz\n",
+        12
+    ),
+    ?assertFormat(
+        "Foo orelse Bar orelse Baz\n",
+        "Foo orelse\n"
+        "    Bar orelse\n"
+        "    Baz\n",
+        20
+    ),
+    ?assertFormat(
+        "Foo orelse Bar orelse Baz orelse Abc orelse Cde\n",
+        "Foo orelse\n"
+        "    Bar orelse\n"
+        "    Baz orelse\n"
+        "    Abc orelse\n"
+        "    Cde\n",
+        30
+    ),
+    ?assertFormat(
+        "Foo andalso\n"
+        "    Bar andalso Baz\n",
+        "Foo andalso\n"
+        "    Bar andalso\n"
+        "    Baz\n"
+    ),
+    ?assertSame(
+        "s2c(<<C, Rest/binary>>, Acc) when\n"
+        "    C == $\; orelse\n"
+        "        C == $\$ orelse\n"
+        "        C == $\> orelse\n"
+        "        C == $\< orelse\n"
+        "        C == $\/\n"
+        "->\n"
+        "    ok.\n"
+     ),
+     ?assertSame(
+        "[\n"
+        "    Slash ++\n"
+        "        binary_to_list(A2) ++\n"
+        "        SlashArraySlash ++\n"
+        "        binary_to_list(A1) ++\n"
+        "        Slash ++\n"
+        "        graphviz_edge_label(L)\n"
+        "    || {_, A1, A2, L} <- Es\n"
+        "].\n"
     ).
 
 tuple(Config) when is_list(Config) ->


### PR DESCRIPTION
Fixes #136 and #149

```erlang
Foo orelse Bar orelse Baz
```

will now break to

```erlang
Foo orelse
    Bar orelse
    Baz
```

Instead of

```erlang
Foo orelse
    Bar orelse Baz
```