### PR TITLE
bind pipe tighter

### DIFF
--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -86,9 +86,9 @@ Nonassoc 800 ':='.
 %% Types
 
 Right 40 '::'.
-Right 170 '|'.
-Nonassoc 200 '..'.
-Nonassoc 200 '*'. % for binary expressions
+Right 900 '|'.
+Nonassoc 1000 '..'.
+Nonassoc 1000 '*'. % for binary expressions
 
 node -> attribute dot : setelement(2, '$1', ?range_anno('$1', '$2')).
 node -> function dot : setelement(2, '$1', ?range_anno('$1', '$2')).

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2143,6 +2143,19 @@ record_definition(Config) when is_list(Config) ->
     ).
 
 spec(Config) when is_list(Config) ->
+    ?assertFormat(
+        "-spec child_spec(#{\n"
+        "    name => {local, Name :: atom()} | {global, GlobalName :: any()} | {via, Module :: atom(), ViaName :: any()},\n"
+        "    another_field => atom()\n"
+        "}) -> supervisor:child_spec().\n",
+        "-spec child_spec(#{\n"
+        "    name =>\n"
+        "        {local, Name :: atom()}\n"
+        "        | {global, GlobalName :: any()}\n"
+        "        | {via, Module :: atom(), ViaName :: any()},\n"
+        "    another_field => atom()\n"
+        "}) -> supervisor:child_spec().\n"
+    ),
     ?assertSame(
         "-spec foo(Int) -> atom() when Int :: integer().\n"
     ),


### PR DESCRIPTION
Fixes #181

When debugging 181 I found that 
```erlang
name =>
        {local, Name :: atom()} |
    {global, GlobalName :: any()} |
    {via, Module :: atom(), ViaName :: any()}
```

Was parsed as
```
name =>
        {local, Name :: atom()}
```
and then the rest, but the pipe needed to bind tighter than the `=>` operator.
