### PR TITLE
Warn on long lines

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -100,7 +100,12 @@ format_string(String, Options) ->
                     end,
                 Formatted = format_nodes(NodesWithPragma, PrintWidth),
                 verify_nodes("nofile", NodesWithPragma, Formatted),
-                {ok, unicode:characters_to_list(Formatted), Warnings};
+                VerboseWarnings =
+                    case proplists:get_bool(verbose, Options) of
+                        true -> check_line_lengths("nofile", PrintWidth, Formatted);
+                        false -> []
+                    end,
+                {ok, unicode:characters_to_list(Formatted), Warnings ++ VerboseWarnings};
             {skip, RawString} ->
                 {skip, RawString}
         end

--- a/src/erlfmt_cli.erl
+++ b/src/erlfmt_cli.erl
@@ -145,7 +145,10 @@ format_file(FileName, Config) ->
         true -> io:format(standard_error, "Formatting ~s\n", [FileName]);
         false -> ok
     end,
-    Options = [{pragma, Pragma}] ++ [{print_width, PrintWidth} || PrintWidth =/= undefined],
+    Options =
+        [{pragma, Pragma}] ++
+            [{print_width, PrintWidth} || PrintWidth =/= undefined] ++
+            [verbose || Verbose],
     Result =
         case {Out, FileName} of
             {check, stdin} ->

--- a/test/erlfmt_SUITE_data/overlong.erl
+++ b/test/erlfmt_SUITE_data/overlong.erl
@@ -5,6 +5,7 @@
 process(_Arg1, Arg2, _Arg3, _Arg4, _Arg5, _Arg6) ->
     % Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut ultricies magna. Donec sagittis vulputate tempus.
     % Curabitur nisi metus.
+    % Overlong, in bytes: 色は匂へど 散りぬるを 我が世誰ぞ 常ならむ 有為の奥山 今日越えて 浅き夢見じ 酔ひもせず
     other_module:call('some.atom'),
     other_module:call(with_many, extremely_long_arguments, that_should_really, be_broken_up, size(Arg2)),
     ok.

--- a/test/erlfmt_SUITE_data/overlong.erl.formatted
+++ b/test/erlfmt_SUITE_data/overlong.erl.formatted
@@ -5,6 +5,7 @@
 process(_Arg1, Arg2, _Arg3, _Arg4, _Arg5, _Arg6) ->
     % Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut ultricies magna. Donec sagittis vulputate tempus.
     % Curabitur nisi metus.
+    % Overlong, in bytes: 色は匂へど 散りぬるを 我が世誰ぞ 常ならむ 有為の奥山 今日越えて 浅き夢見じ 酔ひもせず
     other_module:call('some.atom'),
     other_module:call(
         with_many,


### PR DESCRIPTION
Closes #120

Use a map in the return values of the format functions, so that more return data can be added.
Add "verbose warnings", which are only printed if the verbose option is given.