### PR TITLE
Print literal value instead of crashing on missing text annotation

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -115,12 +115,22 @@ expr_to_algebra(Expr) when is_tuple(Expr) ->
 expr_to_algebra(Other) ->
     do_expr_to_algebra(Other).
 
-do_expr_to_algebra({string, Meta, _Value}) ->
-    string_to_algebra(erlfmt_scan:get_anno(text, Meta));
+do_expr_to_algebra({string, Meta, Value}) ->
+    case erlfmt_scan:get_anno(text, Meta, undefined) of
+        undefined ->
+            string_to_algebra(Value);
+        Text ->
+            string_to_algebra(Text)
+    end;
 do_expr_to_algebra({char, #{text := "$ "}, $\s}) ->
     <<"$\\s">>;
-do_expr_to_algebra({Atomic, Meta, _Value}) when ?IS_ATOMIC(Atomic) ->
-    string(erlfmt_scan:get_anno(text, Meta));
+do_expr_to_algebra({Atomic, Meta, Value}) when ?IS_ATOMIC(Atomic) ->
+    case erlfmt_scan:get_anno(text, Meta, undefined) of
+        undefined ->
+            string(io_lib:write(Value));
+        Text ->
+            string(Text)
+    end;
 do_expr_to_algebra({concat, _Meta, Values}) ->
     concat_to_algebra(Values);
 do_expr_to_algebra({op, _Meta, Op, Expr}) ->


### PR DESCRIPTION
This allows you to format syntax trees that have been synthesized outside erlfmt without forcing the caller to add "text" annotations for all literals in order to print them.