### PR TITLE
Only write to file the formatted code when it is different to the current one

### DIFF
--- a/src/erlfmt_cli.erl
+++ b/src/erlfmt_cli.erl
@@ -202,7 +202,14 @@ write_formatted(FileName, Formatted, Out) ->
             print_error_info({OutFileName, 0, file, Reason1}),
             error
     end,
-    case file:write_file(OutFileName, unicode:characters_to_binary(Formatted)) of
+    {ok, OriginalBin} = file:read_file(FileName),
+    case unicode:characters_to_binary(Formatted) of
+        OriginalBin -> ok;
+        FormattedBin -> write_file(OutFileName, FormattedBin)
+    end.
+
+write_file(OutFileName, FormattedBin) ->
+    case file:write_file(OutFileName, unicode:characters_to_binary(FormattedBin)) of
         ok ->
             ok;
         {error, Reason2} ->


### PR DESCRIPTION
Fixes #231. I couldn't find any test that checks the writing to but let me know if you think it is needed and I'll try to implement one.

I used `stats` to check if it works: 
```bash
$ stat rebar.config | grep -F 'Modify'                                                                                                                                            0s
Modify: 2021-01-06 09:38:08.204419183 +0000
$ _build/release/bin/erlfmt -w "{src,include,test}/*.{hrl,erl}" rebar.config
$ stat rebar.config | grep -F 'Modify'                                                                                                                                            0s
Modify: 2021-01-06 09:38:08.204419183 +0000
```
 