### PR TITLE
preserve a single empty line between attributes

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -4,6 +4,3 @@ include_dirs:
   - "_build/*/lib/*/include"
 deps_dirs:
   - "_build/*/lib/*"
-diagnostics:
-  disabled:
-    - xref

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1081,7 +1081,7 @@ snapshot_same(Module, Config) ->
     case erlfmt:format_string(Original, [{pragma, Pragma}]) of
         {ok, Original, _} -> ok;
         {skip, _} -> ok;
-        {ok, Other, _} -> ct:fail("unexpected:~n~s~n", [Other]);
+        {ok, Other, _} -> ct:fail({unexpected, Other, expected, Original});
         Other -> ct:fail("unexpected: ~p~n", [Other])
     end.
 
@@ -1282,7 +1282,7 @@ insert_pragma(Config) when is_list(Config) ->
         "-export([f/3]).\n",
         insert_pragma_string(
             "%% attached comment\n"
-            "-module(pragma)\n."
+            "-module(pragma).\n"
             "\n"
             "-export([f/3]).\n"
         )
@@ -1297,7 +1297,7 @@ insert_pragma(Config) when is_list(Config) ->
         insert_pragma_string(
             "%% single comment\n"
             "\n"
-            "-module(pragma)\n."
+            "-module(pragma).\n"
             "\n"
             "-export([f/3]).\n"
         )
@@ -1318,7 +1318,7 @@ insert_pragma(Config) when is_list(Config) ->
             "%% LICENSE\n"
             "%% LICENSE\n"
             "\n"
-            "-module(pragma)\n."
+            "-module(pragma).\n"
             "\n"
             "-export([f/3]).\n"
         )
@@ -1354,8 +1354,8 @@ insert_pragma_string(String) ->
     {ok, StringWithPragma, []} = erlfmt:format_string(String, [{pragma, insert}]),
     %% check that insert_pragma_nodes doesn't insert a pragma, when one has already been inserted.
     ?assertEqual(
-        {ok, StringWithPragma, []},
-        erlfmt:format_string(StringWithPragma, [{pragma, insert}])
+        erlfmt:format_string(StringWithPragma, [{pragma, insert}]),
+        {ok, StringWithPragma, []}
     ),
     StringWithPragma.
 

--- a/test/erlfmt_SUITE_data/broken.erl.formatted
+++ b/test/erlfmt_SUITE_data/broken.erl.formatted
@@ -1,7 +1,6 @@
 -module(broken).
 
 -export([foo/0, bar/0]).
-
 -define(PARENS, ()).
 
 foo?PARENS %% comment

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1963,6 +1963,15 @@ attribute(Config) when is_list(Config) ->
         "    foo/2, foo/3,\n"
         "    bar/2\n"
         "]).\n"
+    ),
+    ?assertFormat(
+        "-type str() :: string().\n"
+        "\n"
+        "\n"
+        "-type int() :: integer().\n",
+        "-type str() :: string().\n"
+        "\n"
+        "-type int() :: integer().\n"
     ).
 
 exportimport(Config) when is_list(Config) ->


### PR DESCRIPTION
Fixes https://github.com/WhatsApp/erlfmt/issues/233

## Tests

`erlfmt_SUITE_data/attribute.erl` already tests quite a few cases of preserving empty lines.
Added one test to make sure that more than one empty line is reduced to a single empty line.