### PR TITLE
fix: Crash formatting qlc_SUITE in OTP

### DIFF
--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -112,8 +112,9 @@ take_comments(Line, Comments) ->
 
 insert_nested(Node, []) ->
     {Node, []};
-insert_nested({Atomic, _, _} = Node, Comments) when ?IS_ATOMIC(Atomic) ->
-    {Node, Comments};
+insert_nested({Atomic, _, _} = Node0, Comments) when ?IS_ATOMIC(Atomic) ->
+    Node = put_pre_comments(Node0, Comments),
+    {Node, []};
 insert_nested({concat, Meta, Strings0}, Comments0) ->
     {Strings, Comments} = insert_expr_list(Strings0, Comments0),
     {{concat, Meta, Strings}, Comments};

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2610,4 +2610,22 @@ comment(Config) when is_list(Config) ->
         "a,\n"
         "%% post comment\n"
         "b.\n"
+    ),
+    ?assertFormat(
+        "\"a,\n"
+        "b\" % c\n"
+        ".\n",
+        "% c\n"
+        "\"a,\\n\"\n"
+        "\"b\".\n"
+    ),
+    ?assertFormat(
+        "%% pre\n"
+        "\"a,\n"
+        "b\" % c\n"
+        ".\n",
+        "%% pre\n"
+        "% c\n"
+        "\"a,\\n\"\n"
+        "\"b\".\n"
     ).


### PR DESCRIPTION
Fixes #236