### PR TITLE
Adjust AST for try clauses such that they do not move comments around

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -223,6 +223,8 @@ do_expr_to_algebra({fa_group, _Meta, GroupedExports}) ->
     fa_group_to_algebra(GroupedExports);
 do_expr_to_algebra({exprs, _Meta, Exprs}) ->
     block_to_algebra(Exprs);
+do_expr_to_algebra({clauses, _Meta, Clauses}) ->
+    clauses_to_algebra(Clauses);
 do_expr_to_algebra(Other) ->
     error(unsupported, [Other]).
 
@@ -714,13 +716,13 @@ receive_after_to_algebra(Expr, Body) ->
 try_to_algebra(Exprs, OfClauses, CatchClauses, After) ->
     Clauses =
         [try_of_block(Exprs, OfClauses)] ++
-            [try_catch_to_algebra(CatchClauses) || CatchClauses =/= []] ++
+            [try_catch_to_algebra(CatchClauses) || CatchClauses =/= none] ++
             [try_after_to_algebra(After) || After =/= []] ++
             [<<"end">>],
     concat(force_breaks(), (group(fold_doc(fun erlfmt_algebra:line/2, Clauses)))).
 
 try_catch_to_algebra(Clauses) ->
-    group(nest(line(<<"catch">>, clauses_to_algebra(Clauses)), ?INDENT)).
+    group(nest(line(<<"catch">>, expr_to_algebra(Clauses)), ?INDENT)).
 
 try_after_to_algebra(Exprs) ->
     ExprsD = block_to_algebra(Exprs),

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -732,12 +732,12 @@ try_of_block(Exprs, OfClauses) ->
     ExprsD = block_to_algebra(Exprs),
 
     case OfClauses of
-        [] ->
+        none ->
             group(nest(line(<<"try">>, ExprsD), ?INDENT));
         _ ->
             concat(
                 surround(<<"try">>, <<" ">>, ExprsD, <<" ">>, <<"of">>),
-                nest(concat(line(), clauses_to_algebra(OfClauses)), ?INDENT)
+                nest(concat(line(), expr_to_algebra(OfClauses)), ?INDENT)
             )
     end.
 

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -434,18 +434,19 @@ fun_clause -> var pat_argument_list clause_guard clause_body :
     {clause, ?range_anno('$1', '$4'), Head, '$3', ?val('$4')}.
 
 try_expr -> 'try' exprs 'of' cr_clauses try_catch :
-    {TryClauses, _, After} = '$5',
-    {'try', ?range_anno('$1', '$5'), '$2', '$4', TryClauses, After}.
+    {TryClauses, _, NextToken, After} = '$5',
+    OfClauses = {clauses, ?range_upto_anno('$3', NextToken), '$4'},
+    {'try', ?range_anno('$1', '$5'), '$2', OfClauses, TryClauses, After}.
 try_expr -> 'try' exprs try_catch :
-    {TryClauses, _, After} = '$3',
-    {'try', ?range_anno('$1', '$3'), '$2', [], TryClauses, After}.
+    {TryClauses, _, _NextToken, After} = '$3',
+    {'try', ?range_anno('$1', '$3'), '$2', none, TryClauses, After}.
 
 try_catch -> 'catch' try_clauses 'end' :
-        {{clauses, ?range_anno('$1', '$3'), '$2'}, ?anno('$3'), []}.
+        {{clauses, ?range_anno('$1', '$3'), '$2'}, ?anno('$3'), '$1', []}.
 try_catch -> 'catch' try_clauses 'after' exprs 'end' :
-        {{clauses, ?range_anno('$1', '$3'), '$2'}, ?anno('$5'), '$4'}.
+        {{clauses, ?range_anno('$1', '$3'), '$2'}, ?anno('$5'), '$1', '$4'}.
 try_catch -> 'after' exprs 'end' :
-        {none, ?anno('$3'), '$2'}.
+        {none, ?anno('$3'), '$1', '$2'}.
 
 try_clauses -> try_clause : ['$1'].
 try_clauses -> try_clause ';' try_clauses : ['$1' | '$3'].
@@ -979,6 +980,11 @@ Erlang code.
     end_location => map_get(end_location, ?anno(Tok2))
 }).
 
+-define(range_upto_anno(Tok1, Tok2), #{
+    location => map_get(location, ?anno(Tok1)),
+    end_location => decrement_location(map_get(location, ?anno(Tok2)))
+}).
+
 %% Entry points compatible to old erl_parse.
 
 -spec parse_node(Tokens) -> {ok, AbsNode} | {error, ErrorInfo} when
@@ -1053,3 +1059,5 @@ ret_err(Anno, S) ->
 set_parens(Expr) -> erlfmt_scan:put_anno(parens, true, Expr).
 
 delete_parens(Expr) -> erlfmt_scan:delete_anno(parens, Expr).
+
+decrement_location({Line, Col}) -> {Line, Col - 1}.

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -436,10 +436,12 @@ fun_clause -> var pat_argument_list clause_guard clause_body :
 try_expr -> 'try' exprs 'of' cr_clauses try_catch :
     {TryClauses, _, NextToken, After} = '$5',
     OfClauses = {clauses, ?range_upto_anno('$3', NextToken), '$4'},
-    {'try', ?range_anno('$1', '$5'), '$2', OfClauses, TryClauses, After}.
+    Body = {body, ?range_upto_anno('$1', '$3'), '$2'},
+    {'try', ?range_anno('$1', '$5'), Body, OfClauses, TryClauses, After}.
 try_expr -> 'try' exprs try_catch :
-    {TryClauses, _, _NextToken, After} = '$3',
-    {'try', ?range_anno('$1', '$3'), '$2', none, TryClauses, After}.
+    {TryClauses, _, NextToken, After} = '$3',
+    Body = {body, ?range_upto_anno('$1', NextToken), '$2'},
+    {'try', ?range_anno('$1', '$3'), Body, none, TryClauses, After}.
 
 try_catch -> 'catch' try_clauses 'end' :
         {{clauses, ?range_anno('$1', '$3'), '$2'}, ?anno('$3'), '$1', []}.

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -441,11 +441,11 @@ try_expr -> 'try' exprs try_catch :
     {'try', ?range_anno('$1', '$3'), '$2', [], TryClauses, After}.
 
 try_catch -> 'catch' try_clauses 'end' :
-        {'$2', ?anno('$3'), []}.
+        {{clauses, ?range_anno('$1', '$3'), '$2'}, ?anno('$3'), []}.
 try_catch -> 'catch' try_clauses 'after' exprs 'end' :
-        {'$2', ?anno('$5'), '$4'}.
+        {{clauses, ?range_anno('$1', '$3'), '$2'}, ?anno('$5'), '$4'}.
 try_catch -> 'after' exprs 'end' :
-        {[], ?anno('$3'), '$2'}.
+        {none, ?anno('$3'), '$2'}.
 
 try_clauses -> try_clause : ['$1'].
 try_clauses -> try_clause ';' try_clauses : ['$1' | '$3'].

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -232,12 +232,12 @@ insert_nested({'if', Meta, Clauses0}, Comments0) ->
 insert_nested({'try', Meta, Exprs0, OfClauses0, CatchClauses0, []}, Comments0) ->
     {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
     {OfClauses, Comments2} = insert_expr_list(OfClauses0, Comments1),
-    CatchClauses = insert_expr_container(CatchClauses0, Comments2),
+    {CatchClauses, []} = insert_expr(CatchClauses0, Comments2),
     {{'try', Meta, Exprs, OfClauses, CatchClauses, []}, []};
 insert_nested({'try', Meta, Exprs0, OfClauses0, CatchClauses0, After0}, Comments0) ->
     {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
     {OfClauses, Comments2} = insert_expr_list(OfClauses0, Comments1),
-    {CatchClauses, Comments3} = insert_expr_list(CatchClauses0, Comments2),
+    {CatchClauses, Comments3} = insert_expr(CatchClauses0, Comments2),
     After = insert_expr_container(After0, Comments3),
     {{'try', Meta, Exprs, OfClauses, CatchClauses, After}, []};
 insert_nested({spec, Meta, Name, Clauses0}, Comments0) ->
@@ -260,6 +260,9 @@ insert_nested({'catch', Meta, Args0}, Comments0) ->
 insert_nested({args, Meta, Args0}, Comments0) ->
     Args = insert_expr_container(Args0, Comments0),
     {{args, Meta, Args}, []};
+insert_nested({clauses, Meta, Clauses0}, Comments0) ->
+    Clauses = insert_expr_container(Clauses0, Comments0),
+    {{clauses, Meta, Clauses}, []};
 insert_nested({Name, Meta}, Comments) ->
     {{Name, Meta}, Comments}.
 

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -231,13 +231,13 @@ insert_nested({'if', Meta, Clauses0}, Comments0) ->
     {{'if', Meta, Clauses}, []};
 insert_nested({'try', Meta, Exprs0, OfClauses0, CatchClauses0, []}, Comments0) ->
     {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
-    {OfClauses, Comments2} = insert_expr_list(OfClauses0, Comments1),
-    {CatchClauses, []} = insert_expr(CatchClauses0, Comments2),
+    {OfClauses, Comments2} = insert_expr_or_none(OfClauses0, Comments1),
+    {CatchClauses, []} = insert_expr_or_none(CatchClauses0, Comments2),
     {{'try', Meta, Exprs, OfClauses, CatchClauses, []}, []};
 insert_nested({'try', Meta, Exprs0, OfClauses0, CatchClauses0, After0}, Comments0) ->
     {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
-    {OfClauses, Comments2} = insert_expr_list(OfClauses0, Comments1),
-    {CatchClauses, Comments3} = insert_expr(CatchClauses0, Comments2),
+    {OfClauses, Comments2} = insert_expr_or_none(OfClauses0, Comments1),
+    {CatchClauses, Comments3} = insert_expr_or_none(CatchClauses0, Comments2),
     After = insert_expr_container(After0, Comments3),
     {{'try', Meta, Exprs, OfClauses, CatchClauses, After}, []};
 insert_nested({spec, Meta, Name, Clauses0}, Comments0) ->
@@ -265,6 +265,9 @@ insert_nested({clauses, Meta, Clauses0}, Comments0) ->
     {{clauses, Meta, Clauses}, []};
 insert_nested({Name, Meta}, Comments) ->
     {{Name, Meta}, Comments}.
+
+insert_expr_or_none(none, Comments) -> {none, Comments};
+insert_expr_or_none(Expr, Comments) -> insert_expr(Expr, Comments).
 
 put_pre_dot_comments(NodeOrMeta, []) ->
     NodeOrMeta;

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -229,17 +229,17 @@ insert_nested({'receive', Meta, Clauses0, AfterExpr0, AfterBody0}, Comments0) ->
 insert_nested({'if', Meta, Clauses0}, Comments0) ->
     Clauses = insert_expr_container(Clauses0, Comments0),
     {{'if', Meta, Clauses}, []};
-insert_nested({'try', Meta, Exprs0, OfClauses0, CatchClauses0, []}, Comments0) ->
-    {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
+insert_nested({'try', Meta, Body0, OfClauses0, CatchClauses0, []}, Comments0) ->
+    {Body, Comments1} = insert_expr(Body0, Comments0),
     {OfClauses, Comments2} = insert_expr_or_none(OfClauses0, Comments1),
     {CatchClauses, []} = insert_expr_or_none(CatchClauses0, Comments2),
-    {{'try', Meta, Exprs, OfClauses, CatchClauses, []}, []};
-insert_nested({'try', Meta, Exprs0, OfClauses0, CatchClauses0, After0}, Comments0) ->
-    {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
+    {{'try', Meta, Body, OfClauses, CatchClauses, []}, []};
+insert_nested({'try', Meta, Body0, OfClauses0, CatchClauses0, After0}, Comments0) ->
+    {Body, Comments1} = insert_expr(Body0, Comments0),
     {OfClauses, Comments2} = insert_expr_or_none(OfClauses0, Comments1),
     {CatchClauses, Comments3} = insert_expr_or_none(CatchClauses0, Comments2),
     After = insert_expr_container(After0, Comments3),
-    {{'try', Meta, Exprs, OfClauses, CatchClauses, After}, []};
+    {{'try', Meta, Body, OfClauses, CatchClauses, After}, []};
 insert_nested({spec, Meta, Name, Clauses0}, Comments0) ->
     Clauses = insert_expr_container(Clauses0, Comments0),
     {{spec, Meta, Name, Clauses}, []};
@@ -263,6 +263,9 @@ insert_nested({args, Meta, Args0}, Comments0) ->
 insert_nested({clauses, Meta, Clauses0}, Comments0) ->
     Clauses = insert_expr_container(Clauses0, Comments0),
     {{clauses, Meta, Clauses}, []};
+insert_nested({body, Meta, Exprs0}, Comments0) ->
+    Exprs = insert_expr_container(Exprs0, Comments0),
+    {{body, Meta, Exprs}, []};
 insert_nested({Name, Meta}, Comments) ->
     {{Name, Meta}, Comments}.
 

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -729,7 +729,8 @@ clauses(Config) when is_list(Config) ->
         parse_expr("receive _ -> true end")
     ),
     ?assertMatch(
-        {'try', _, [{atom, _, ok}], [{clause, _, {var, _, '_'}, empty, [{atom, _, ok}]}],
+        {'try', _, [{atom, _, ok}],
+            {clauses, _, [{clause, _, {var, _, '_'}, empty, [{atom, _, ok}]}]},
             {clauses, _, [
                 {clause, _, {var, _, '_'}, empty, [{atom, _, ok}]},
                 {clause, _, {'catch', _, [{var, _, '_'}, {var, _, '_'}]}, empty, [

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -730,7 +730,7 @@ clauses(Config) when is_list(Config) ->
     ),
     ?assertMatch(
         {'try', _, [{atom, _, ok}], [{clause, _, {var, _, '_'}, empty, [{atom, _, ok}]}],
-            [
+            {clauses, _, [
                 {clause, _, {var, _, '_'}, empty, [{atom, _, ok}]},
                 {clause, _, {'catch', _, [{var, _, '_'}, {var, _, '_'}]}, empty, [
                     {atom, _, ok}
@@ -738,7 +738,7 @@ clauses(Config) when is_list(Config) ->
                 {clause, _, {'catch', _, [{var, _, '_'}, {var, _, '_'}, {var, _, '_'}]}, empty, [
                     {atom, _, ok}
                 ]}
-            ],
+            ]},
             []},
         parse_expr("try ok of _ -> ok catch _ -> ok; _:_ -> ok; _:_:_ -> ok end")
     ).

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -729,7 +729,7 @@ clauses(Config) when is_list(Config) ->
         parse_expr("receive _ -> true end")
     ),
     ?assertMatch(
-        {'try', _, [{atom, _, ok}],
+        {'try', _, {body, _, [{atom, _, ok}]},
             {clauses, _, [{clause, _, {var, _, '_'}, empty, [{atom, _, ok}]}]},
             {clauses, _, [
                 {clause, _, {var, _, '_'}, empty, [{atom, _, ok}]},

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1711,13 +1711,13 @@ receive_expression(Config) when is_list(Config) ->
         "    2 -> two\n"
         "end\n"
     ),
-    ?assertSame(
-        "receive\n"
-        "after\n"
-        "    % foo\n"
-        "    0 -> ok\n"
-        "end\n"
-    ),
+    % ?assertSame(
+    %     "receive\n"
+    %     "after\n"
+    %     "    % foo\n"
+    %     "    0 -> ok\n"
+    %     "end\n"
+    % ),
     ?assertFormat(
         "receive\n"
         "    1 -> ok\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1853,7 +1853,16 @@ try_expression(Config) when is_list(Config) ->
         "try 2 of\n"
         "    _ ->\n"
         "        undefined\n"
-        "    %% after catch\n"
+        "    %% after of\n"
+        "after\n"
+        "    ok\n"
+        "    %% after after\n"
+        "end\n"
+    ),
+    ?assertSame(
+        "try\n"
+        "    2\n"
+        "    % after expr\n"
         "after\n"
         "    ok\n"
         "    %% after after\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1710,6 +1710,30 @@ receive_expression(Config) when is_list(Config) ->
         "    % two\n"
         "    2 -> two\n"
         "end\n"
+    ),
+    % ?assertSame(
+    %     "receive\n"
+    %     "after\n"
+    %     "    % foo\n"
+    %     "    0 -> ok\n"
+    %     "end\n"
+    % ),
+    ?assertFormat(
+        "receive\n"
+        "    1 -> ok\n"
+        "    %% after receive\n"
+        "after\n"
+        "    0 -> ok\n"
+        "    %% after after for receive\n"
+        "end\n",
+        "receive\n"
+        "    1 -> ok\n"
+        "%% after receive\n"
+        "\n"
+        "after 0 ->\n"
+        "    ok\n"
+        "    %% after after for receive\n"
+        "end\n"
     ).
 
 try_expression(Config) when is_list(Config) ->
@@ -1811,6 +1835,18 @@ try_expression(Config) when is_list(Config) ->
         "after\n"
         "    Expr1,\n"
         "    Expr2\n"
+        "end\n"
+    ),
+    ?assertSame(
+        "try\n"
+        "    2\n"
+        "catch\n"
+        "    _ ->\n"
+        "        undefined\n"
+        "    %% after catch\n"
+        "after\n"
+        "    ok\n"
+        "    %% after after\n"
         "end\n"
     ).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1711,13 +1711,13 @@ receive_expression(Config) when is_list(Config) ->
         "    2 -> two\n"
         "end\n"
     ),
-    % ?assertSame(
-    %     "receive\n"
-    %     "after\n"
-    %     "    % foo\n"
-    %     "    0 -> ok\n"
-    %     "end\n"
-    % ),
+    ?assertSame(
+        "receive\n"
+        "after\n"
+        "    % foo\n"
+        "    0 -> ok\n"
+        "end\n"
+    ),
     ?assertFormat(
         "receive\n"
         "    1 -> ok\n"
@@ -1841,6 +1841,16 @@ try_expression(Config) when is_list(Config) ->
         "try\n"
         "    2\n"
         "catch\n"
+        "    _ ->\n"
+        "        undefined\n"
+        "    %% after catch\n"
+        "after\n"
+        "    ok\n"
+        "    %% after after\n"
+        "end\n"
+    ),
+    ?assertSame(
+        "try 2 of\n"
         "    _ ->\n"
         "        undefined\n"
         "    %% after catch\n"


### PR DESCRIPTION
Tackled parts of https://github.com/WhatsApp/erlfmt/issues/125 , but issues with receive statements persist and will be tackled at a later date.