### PR TITLE
preserve newline after's arrow

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -707,13 +707,12 @@ single_clause_spec_to_algebra(Name, {spec_clause, CMeta, Head, Body, Guards}) ->
     {args, AMeta, Args} = Head,
     clauses_to_algebra([{spec_clause, CMeta, {call, AMeta, Name, Args}, Body, Guards}]).
 
-receive_after_to_algebra(Expr, Body) ->
+receive_after_to_algebra(Expr, [HBody | _] = Body) ->
     ExprD = do_expr_to_algebra(Expr),
     BodyD = block_to_algebra(Body),
-
     HeadD = concat([<<"after ">>, ExprD, <<" ->">>]),
-    Doc = group(nest(break(HeadD, BodyD), ?INDENT)),
-    combine_comments(element(2, Expr), Doc).
+    Doc = concat([HeadD, break(), maybe_force_breaks(has_break_between(Expr, HBody)), BodyD]),
+    combine_comments(element(2, Expr), group(nest(Doc, ?INDENT))).
 
 try_to_algebra(Body, OfClauses, CatchClauses, After) ->
     Clauses =

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1634,6 +1634,13 @@ receive_expression(Config) when is_list(Config) ->
         "after 0 -> ok\n"
         "end\n"
     ),
+    ?assertSame(
+        "receive\n"
+        "    1 -> ok\n"
+        "after 0 ->\n"
+        "    ok\n"
+        "end\n"
+    ),
     ?assertFormat(
         "receive {Long} -> Expression end",
         "receive\n"


### PR DESCRIPTION
Fixes https://github.com/WhatsApp/erlfmt/issues/180