### PR TITLE
updated formatting for list comprehensions to dedent double pipes just a little

### DIFF
--- a/doc/FormattingDecisionListComprehensions.md
+++ b/doc/FormattingDecisionListComprehensions.md
@@ -111,7 +111,7 @@ This doesn't seem very consistent with how lists are formatted.
   - ✅ Handles multiline expression consistently
   - ✅ Indenting by 4
 
-`erlfmt` formats by dedenting the double pipes to the left, but just a little:
+Another alternative is dedenting the double pipes to the left, but just a little:
 
 ```erlang formatted list_comp_1
 [
@@ -139,6 +139,45 @@ Here is an example with a multiline expression, that shows what a long argument 
         ALongArgument
     )
  || {A, B} <- Cs,
+    filter(B)
+]
+```
+
+## Two spaces after double pipes
+
+  - ✅ Differentiating
+  - ✅ Consistent with lists
+  - ✅ Handles multiline expression consistently
+  - ✅ Indenting by 4
+
+We can also considered dedenting the pipes, with two spaces after, to keep expressions aligned:
+
+```erlang
+[
+    function_with_long_name(A)
+||  {A, B} <- Cs, filter(B)
+]
+```
+
+All parts of the list comprehension stay aligned if they are broken apart at a consistent 4 spaces:
+
+```erlang
+[
+    function_with_long_name(A)
+||  {A, B} <- Cs,
+    filter(B)
+]
+```
+
+Here is an example with a multiline expression, that shows what a long argument in the function would look like:
+
+```erlang
+[
+    function_with_long_name(
+        A,
+        ALongArgument
+    )
+||  {A, B} <- Cs,
     filter(B)
 ]
 ```

--- a/doc/FormattingDecisionListComprehensions.md
+++ b/doc/FormattingDecisionListComprehensions.md
@@ -17,6 +17,7 @@ We will choose a format that best conforms to our goals:
   - Create/keep differentiation between the generator, body and filters.
   - Consistent with formatting of [Lists](./FormattingDecisionLists.md)
   - Handles multiline expressions consistently.
+  - Indenting by a number other than 4
 
 Here you can see all the other candidates we evaluated against our goals.
 
@@ -25,10 +26,11 @@ Here you can see all the other candidates we evaluated against our goals.
   - ✅ Differentiating
   - ✅ Consistent Lists
   - ✅ Multiline expressions
+  - ❌ Indenting by 4
 
-This is how `erlfmt` formats a multiline list comprehension today:
+We considered indenting the filter expressions by 3.
 
-```erlang formatted list_comp
+```erlang
 [
     function_with_long_name(A)
     || {A, B} <- Cs,
@@ -36,9 +38,9 @@ This is how `erlfmt` formats a multiline list comprehension today:
 ]
 ```
 
-`erlfmt` does allow you to move some parts onto the same line, if they fit `erlfmt` will keep them there:
+This does allow you to move some parts onto the same line, if they fit they will be kept there:
 
-```erlang formatted list_comp_2
+```erlang
 [
     function_with_long_name(A)
     || {A, B} <- Cs, filter(B)
@@ -47,7 +49,7 @@ This is how `erlfmt` formats a multiline list comprehension today:
 
 Here is an example with a multiline expression, that shows what a long argument in the function would look like:
 
-```erlang formatted list_comp_3
+```erlang
 [
     function_with_long_name(
         A,
@@ -63,6 +65,7 @@ Here is an example with a multiline expression, that shows what a long argument 
   - ✅ Differentiating
   - ✅ Consistent with lists
   - ✅ Handles multiline expression consistently
+  - ❌ Indenting by 4
 
 The one negative in the previous example is inconsistent indentation, where `filter(B)` was indented by 3 spaces.
 This alternative tries to correct that, but now we have a misalignment between `{A, B}` and `filter(B)` by a single space.
@@ -80,6 +83,7 @@ This alternative tries to correct that, but now we have a misalignment between `
   - ✅ Differentiating
   - ❌ Consistent with lists
   - ✅ Handles multiline expression consistently
+  - ✅ Indenting by 4
 
 We also considered dedenting the double pipes to the left.
 
@@ -100,11 +104,51 @@ This doesn't seem very consistent with how lists are formatted.
 ]
 ```
 
+## Dedent double pipes, just a little
+
+  - ✅ Differentiating
+  - ✅ Consistent with lists
+  - ✅ Handles multiline expression consistently
+  - ✅ Indenting by 4
+
+`erlfmt` formats by dedenting the double pipes to the left, but just a little:
+
+```erlang formatted list_comp_1
+[
+    function_with_long_name(A)
+ || {A, B} <- Cs, filter(B)
+]
+```
+
+All parts of the list comprehension stay aligned if they are broken apart at a consistent 4 spaces:
+
+```erlang formatted list_comp
+[
+    function_with_long_name(A)
+ || {A, B} <- Cs,
+    filter(B)
+]
+```
+
+Here is an example with a multiline expression, that shows what a long argument in the function would look like:
+
+```erlang formatted list_comp_3
+[
+    function_with_long_name(
+        A,
+        ALongArgument
+    )
+ || {A, B} <- Cs,
+    filter(B)
+]
+```
+
 ## Double pipes on their own line
 
   - ✅ Differentiating
   - ❌ Consistent with lists
   - ✅ Handles multiline expression consistently
+  - ✅ Indenting by 4
 
 We also considered giving the double pipes their own line.
 
@@ -130,6 +174,7 @@ We also considered giving the double pipes their own line.
   - ✅ Differentiating
   - ❌ Consistent with lists
   - ❌ Handles multiline expression consistently
+  - ✅ Indenting by 4
 
 The compressed option is inconsistent with how `erlfmt` formats lists,
 but does make differentiation clear.
@@ -156,6 +201,7 @@ There is also a problem with how to indent multiline expressions consistently:
   - ✅ Differentiating
   - ❌ Consistent with lists
   - ❌ Handles multiline expression consistently
+  - ✅ Indenting by 4
 
 We could also consider an option where indentations are made with four spaces.
 

--- a/doc/FormattingDecisionListComprehensions.md
+++ b/doc/FormattingDecisionListComprehensions.md
@@ -111,6 +111,7 @@ This doesn't seem very consistent with how lists are formatted.
   - ✅ Handles multiline expression consistently
   - ✅ Indenting by 4
 
+This is the formatting `erlfmt` chose.
 Another alternative is dedenting the double pipes to the left, but just a little:
 
 ```erlang formatted list_comp_1
@@ -150,6 +151,7 @@ Here is an example with a multiline expression, that shows what a long argument 
   - ✅ Handles multiline expression consistently
   - ✅ Indenting by 4
 
+`erlfmt` chose the above format over this one, purely because this alternative had much larger complexity and seems to require inventing a new operator in the algebra.
 We can also considered dedenting the pipes, with two spaces after, to keep expressions aligned:
 
 ```erlang

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -497,9 +497,9 @@ check_line_lengths(FileName, Width, String, {FirstLineNo, _}) ->
     LastLineNo = FirstLineNo + length(Lines) - 1,
     [
         {FileName, LineNo, ?MODULE, {long_line, string:length(Line), Width}}
-        || {LineNo, Line} <- lists:zip(
-               lists:seq(FirstLineNo, LastLineNo),
-               Lines
-           ),
-           string:length(Line) > Width
+     || {LineNo, Line} <- lists:zip(
+            lists:seq(FirstLineNo, LastLineNo),
+            Lines
+        ),
+        string:length(Line) > Width
     ].

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -552,9 +552,10 @@ comprehension_to_algebra(Expr, [LcExpr | _] = LcExprs, Left, Right) ->
     LcExprsD = lists:map(fun expr_to_algebra/1, LcExprs),
     LcExprD = fold_doc(fun(D, Acc) -> break(concat(D, <<",">>), Acc) end, LcExprsD),
     PostBreak = maybe_force_breaks(has_any_break_between(LcExprs)),
-    PreBreak = concat(maybe_force_breaks(has_break_between(Expr, LcExpr)), break(<<" ">>)),
-    Doc = concat([ExprD, PreBreak, <<"||">>, <<" ">>, nest(group(concat(PostBreak, LcExprD)), 3)]),
-    surround(Left, <<"">>, Doc, <<"">>, Right).
+    PreBreak = concat(maybe_force_breaks(has_break_between(Expr, LcExpr)), break(<<"">>)),
+    IndentExpr = nest(concat(break(<<"">>), ExprD), ?INDENT, break),
+    IdentLcs = nest(group(concat(PostBreak, LcExprD)), ?INDENT),
+    group(concat([Left, IndentExpr, PreBreak, <<" || ">>, IdentLcs, break(<<"">>), Right])).
 
 block_to_algebra([Expr]) ->
     expr_to_algebra(Expr);

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1371,7 +1371,7 @@ overlong_warning(Config) when is_list(Config) ->
     FileLongLines = [{LineNo, Length} || {_, LineNo, _, {long_line, Length, _}} <- FileWarnings],
     StringLongLines = [
         {LineNo, Length}
-        || {_, LineNo, _, {long_line, Length, _}} <- StringWarnings
+     || {_, LineNo, _, {long_line, Length, _}} <- StringWarnings
     ],
     RangeLongLines = [{LineNo, Length} || {_, LineNo, _, {long_line, Length, _}} <- RangeWarnings],
     % Line 6 is an overlong comment

--- a/test/erlfmt_SUITE_data/simple_comments.erl
+++ b/test/erlfmt_SUITE_data/simple_comments.erl
@@ -109,13 +109,13 @@ comprehension() ->
             %% comment 1
             X
         ]
-        || %% comment 2
-           X <-
-               %% comment 4
-               [
-                   %% comment 4
-               ]
-           %% comment 5
+     || %% comment 2
+        X <-
+            %% comment 4
+            [
+                %% comment 4
+            ]
+        %% comment 5
     ].
 
 call() ->

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -470,8 +470,8 @@ binary_operator(Config) when is_list(Config) ->
     ?assertSame(
         "[\n"
         "    Foo\n"
-        "    || {Long, Pattern, YesVeryVeryLong, Pattern, EvenLonger, Longest} <-\n"
-        "           foo(1, 2)\n"
+        " || {Long, Pattern, YesVeryVeryLong, Pattern, EvenLonger, Longest} <-\n"
+        "        foo(1, 2)\n"
         "]\n",
         80
     ),
@@ -1082,7 +1082,7 @@ list_comprehension(Config) when is_list(Config) ->
         "        Long,\n"
         "        Expression\n"
         "    ]\n"
-        "    || X <- Y, X < 10\n"
+        " || X <- Y, X < 10\n"
         "]\n",
         25
     ),
@@ -1092,9 +1092,9 @@ list_comprehension(Config) when is_list(Config) ->
         "]",
         "[\n"
         "    X\n"
-        "    || X <- Y,\n"
-        "       X < 10\n"
-        "       % trailing comment\n"
+        " || X <- Y,\n"
+        "    X < 10\n"
+        "    % trailing comment\n"
         "]\n"
     ),
     ?assertFormat(
@@ -1102,16 +1102,16 @@ list_comprehension(Config) when is_list(Config) ->
         "[\n"
         "    {Very, Long,\n"
         "        Expression}\n"
-        "    || X <- Y, X < 10\n"
+        " || X <- Y, X < 10\n"
         "]\n",
         25
     ),
     ?assertFormat(
-        "[X || X <- LongExpr, X < 10]",
+        "[X || X <- LongExpr123, X < 10]",
         "[\n"
         "    X\n"
-        "    || X <- LongExpr,\n"
-        "       X < 10\n"
+        " || X <- LongExpr123,\n"
+        "    X < 10\n"
         "]\n",
         25
     ),
@@ -1119,9 +1119,9 @@ list_comprehension(Config) when is_list(Config) ->
         "[X || X <- VeryLongExpression, X < 10]",
         "[\n"
         "    X\n"
-        "    || X <-\n"
-        "           VeryLongExpression,\n"
-        "       X < 10\n"
+        " || X <-\n"
+        "        VeryLongExpression,\n"
+        "    X < 10\n"
         "]\n",
         25
     ),
@@ -1129,33 +1129,33 @@ list_comprehension(Config) when is_list(Config) ->
         "lists:unzip([{ALong, B}|| ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)])",
         "lists:unzip([\n"
         "    {ALong, B}\n"
-        "    || ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)\n"
+        " || ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)\n"
         "])\n"
     ),
     ?assertSame(
         "[\n"
         "    a\n"
-        "    || {a, b} <- es\n"
+        " || {a, b} <- es\n"
         "].\n"
     ),
     ?assertSame(
         "[\n"
         "    X\n"
-        "    || true, true, true\n"
+        " || true, true, true\n"
         "].\n"
     ),
     ?assertSame(
         "A = [\n"
         "    a\n"
-        "    || {a, b} <- es,\n"
-        "       filter(b)\n"
+        " || {a, b} <- es,\n"
+        "    filter(b)\n"
         "]\n"
     ),
     ?assertFormat(
         "string:equal([Value || {string, _, Value} <- ValuesL], [Value || {string, _, Value} <- ValuesR]).\n",
         "string:equal([Value || {string, _, Value} <- ValuesL], [\n"
         "    Value\n"
-        "    || {string, _, Value} <- ValuesR\n"
+        " || {string, _, Value} <- ValuesR\n"
         "]).\n"
     ).
 
@@ -1165,24 +1165,24 @@ binary_comprehension(Config) when is_list(Config) ->
     ?assertSame(
         "<<\n"
         "    X\n"
-        "    || <<X, Y>> <= Results,\n"
-        "       X >= Y\n"
+        " || <<X, Y>> <= Results,\n"
+        "    X >= Y\n"
         ">>\n"
     ),
     ?assertFormat(
         "<<(Long + Expression) || X <- Y, X < 10>>",
         "<<\n"
         "    (Long + Expression)\n"
-        "    || X <- Y, X < 10\n"
+        " || X <- Y, X < 10\n"
         ">>\n",
         25
     ),
     ?assertFormat(
-        "<<X || <<X>> <= LongExpr, X < 10>>",
+        "<<X || <<X>> <= LongExpr123, X < 10>>",
         "<<\n"
         "    X\n"
-        "    || <<X>> <= LongExpr,\n"
-        "       X < 10\n"
+        " || <<X>> <= LongExpr123,\n"
+        "    X < 10\n"
         ">>\n",
         25
     ),
@@ -1190,9 +1190,9 @@ binary_comprehension(Config) when is_list(Config) ->
         "<<X || <<X>> <= VeryLongExpression, X < 10>>",
         "<<\n"
         "    X\n"
-        "    || <<X>> <=\n"
-        "           VeryLongExpression,\n"
-        "       X < 10\n"
+        " || <<X>> <=\n"
+        "        VeryLongExpression,\n"
+        "    X < 10\n"
         ">>\n",
         25
     ),
@@ -1200,7 +1200,7 @@ binary_comprehension(Config) when is_list(Config) ->
         "lists:unzip(<<<<ALong, B>>|| ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)>>)",
         "lists:unzip(<<\n"
         "    <<ALong, B>>\n"
-        "    || ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)\n"
+        " || ALong = {_, _, _, {B, _}} <- All, lists:member(B, Keep)\n"
         ">>)\n"
     ).
 


### PR DESCRIPTION
Fixes https://github.com/WhatsApp/erlfmt/issues/148

I have created an updated version of formatting for list comprehensions
It is something we can look at while to help inform our decision in https://github.com/WhatsApp/erlfmt/issues/148

This is the implementation for the option
```erlang
[
    function_with_long_name(A)
 || {A, B} <- Cs,
    filter(B)
]
```