### PR TITLE
fix parsing of bad records

### DIFF
--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -1047,8 +1047,6 @@ record_fields([{macro_call, A, Name, Args}|Fields]) ->
     [{record_field,Name,{macro_call, A, Name, Args}}|record_fields(Fields)];
 record_fields([{atom,Aa,A}|Fields]) ->
     [{record_field,Aa,{atom,Aa,A}}|record_fields(Fields)];
-record_fields([{atom,Aa,A}|Fields]) ->
-    [{record_field,Aa,{atom,Aa,A}}|record_fields(Fields)];
 record_fields([{op,Am,'=',FieldValue,Expr}|Fields]) ->
     [{record_field,Am,FieldValue,Expr}|record_fields(Fields)];
 record_fields([{op,Am,'::',Expr,TypeInfo}|Fields]) ->

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -1045,8 +1045,8 @@ record_tuple(Other) ->
 
 record_fields([{atom,Aa,A}|Fields]) ->
     [{record_field,Aa,{atom,Aa,A}}|record_fields(Fields)];
-record_fields([{op,Am,'=',{atom,Aa,A},Expr}|Fields]) ->
-    [{record_field,Am,{atom,Aa,A},Expr}|record_fields(Fields)];
+record_fields([{op,Am,'=',FieldName,Expr}|Fields]) ->
+    [{record_field,Am,FieldName,Expr}|record_fields(Fields)];
 record_fields([{op,Am,'::',Expr,TypeInfo}|Fields]) ->
     [Field] = record_fields([Expr]),
     [{op,Am,'::',Field,TypeInfo}|record_fields(Fields)];

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -1043,10 +1043,14 @@ record_tuple({tuple,At,Fields}) ->
 record_tuple(Other) ->
     ret_err(?anno(Other), "bad record declaration").
 
+record_fields([{macro_call, A, Name, Args}|Fields]) ->
+    [{record_field,Name,{macro_call, A, Name, Args}}|record_fields(Fields)];
 record_fields([{atom,Aa,A}|Fields]) ->
     [{record_field,Aa,{atom,Aa,A}}|record_fields(Fields)];
-record_fields([{op,Am,'=',FieldName,Expr}|Fields]) ->
-    [{record_field,Am,FieldName,Expr}|record_fields(Fields)];
+record_fields([{atom,Aa,A}|Fields]) ->
+    [{record_field,Aa,{atom,Aa,A}}|record_fields(Fields)];
+record_fields([{op,Am,'=',FieldValue,Expr}|Fields]) ->
+    [{record_field,Am,FieldValue,Expr}|record_fields(Fields)];
 record_fields([{op,Am,'::',Expr,TypeInfo}|Fields]) ->
     [Field] = record_fields([Expr]),
     [{op,Am,'::',Field,TypeInfo}|record_fields(Fields)];

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -1044,7 +1044,7 @@ record_tuple(Other) ->
     ret_err(?anno(Other), "bad record declaration").
 
 record_fields([{macro_call, A, Name, Args}|Fields]) ->
-    [{record_field,Name,{macro_call, A, Name, Args}}|record_fields(Fields)];
+    [{record_field,A,{macro_call, A, Name, Args}}|record_fields(Fields)];
 record_fields([{atom,Aa,A}|Fields]) ->
     [{record_field,Aa,{atom,Aa,A}}|record_fields(Fields)];
 record_fields([{op,Am,'=',FieldValue,Expr}|Fields]) ->

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -964,7 +964,7 @@ Erlang code.
 %% XXX. To be refined.
 -type error_description() :: term().
 -type error_info() :: {erl_anno:line(), module(), error_description()}.
--type token() :: erl_scan:token().
+-type token() :: erlfmt_scan:token().
 
 %% mkop(Op, Arg) -> {op,Anno,Op,Arg}.
 %% mkop(Left, Op, Right) -> {op,Anno,Op,Left,Right}.
@@ -1056,7 +1056,7 @@ record_fields([]) -> [].
 
 -spec ret_err(_, _) -> no_return().
 ret_err(Anno, S) ->
-    return_error(erl_anno:location(Anno), S).
+    return_error(erlfmt_scan:get_anno(location, Anno), S).
 
 set_parens(Expr) -> erlfmt_scan:put_anno(parens, true, Expr).
 

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -80,7 +80,8 @@
     broken_range/1,
     contains_pragma/1,
     insert_pragma/1,
-    overlong_warning/1
+    overlong_warning/1,
+    do_not_crash_on_bad_record/1
 ]).
 
 suite() ->
@@ -122,7 +123,8 @@ groups() ->
             clauses,
             types,
             annos,
-            shebang
+            shebang,
+            do_not_crash_on_bad_record
         ]},
         {smoke_tests, [parallel], [
             {group, snapshot_tests},
@@ -1382,3 +1384,14 @@ overlong_warning(Config) when is_list(Config) ->
     ?assertEqual([], [Line || {8, _} = Line <- StringLongLines]),
     ?assert(lists:member({6, 121}, RangeLongLines)),
     ?assertEqual([], [Line || {8, _} = Line <- RangeLongLines]).
+
+do_not_crash_on_bad_record(Config) when is_list(Config) ->
+    %% bad record declaration
+    {ok, _, _} = erlfmt:read_nodes_string("nofile","-record(r, [1])."),
+    %% bad record field
+    {ok, _, _} = erlfmt:read_nodes_string("nofile","-record(r, {2})."),
+    %% bad record macro field
+    {ok, _, _} = erlfmt:read_nodes_string("nofile",
+        "-define(F1, field1).\n"
+        "-record(r, {?F1}).\n"
+    ).

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1387,11 +1387,12 @@ overlong_warning(Config) when is_list(Config) ->
 
 do_not_crash_on_bad_record(Config) when is_list(Config) ->
     %% bad record declaration
-    {ok, _, _} = erlfmt:read_nodes_string("nofile","-record(r, [1])."),
+    {ok, _, _} = erlfmt:read_nodes_string("nofile", "-record(r, [1])."),
     %% bad record field
-    {ok, _, _} = erlfmt:read_nodes_string("nofile","-record(r, {2})."),
+    {ok, _, _} = erlfmt:read_nodes_string("nofile", "-record(r, {2})."),
     %% bad record macro field
-    {ok, _, _} = erlfmt:read_nodes_string("nofile",
+    {ok, _, _} = erlfmt:read_nodes_string(
+        "nofile",
         "-define(F1, field1).\n"
         "-record(r, {?F1}).\n"
     ).

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1395,4 +1395,9 @@ do_not_crash_on_bad_record(Config) when is_list(Config) ->
         "nofile",
         "-define(F1, field1).\n"
         "-record(r, {?F1}).\n"
+    ),
+    %% bad record macro field 2
+    {ok, _, _} = erlfmt:read_nodes_string(
+        "nofile",
+        "-record(foo, {?FOO, b :: any()})."
     ).

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2360,6 +2360,10 @@ record_definition(Config) when is_list(Config) ->
         "        key2 => []\n"
         "    } :: type()\n"
         "}).\n"
+    ),
+    %% bad record should not crash during formatting
+    ?assertSame(
+        "-record(foo, {?FOO}).\n"
     ).
 
 spec(Config) when is_list(Config) ->

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2361,9 +2361,12 @@ record_definition(Config) when is_list(Config) ->
         "    } :: type()\n"
         "}).\n"
     ),
-    %% bad record should not crash during formatting
+    %% macro in record should not crash during formatting
     ?assertSame(
         "-record(foo, {?FOO}).\n"
+    ),
+    ?assertSame(
+        "-record(foo, {?FOO, b :: any()}).\n"
     ).
 
 spec(Config) when is_list(Config) ->


### PR DESCRIPTION
Fixes https://github.com/WhatsApp/erlfmt/issues/260

Seems `erl_anno:location` crashes, since we have a `erlfmt_scan:anno()` and not a type from `erl_anno`.
I changed to it rather call `erlfmt_scan:get_anno(location, Anno)` as I assume this is what was intended.

Also fixed the type annotation for `token()` to point to `erlfmt_scan:token()` as pointed out by @gomoripeti 
```
-spec parse_node(Tokens) -> {ok, AbsNode} | {error, ErrorInfo} when
      Tokens :: [token()],
      AbsNode :: abstract_node(),
      ErrorInfo :: error_info()
```

Since it seems the tokens passed to parse_node come from

```
-spec string_node(string()) -> node_ret().
```

where `node_ret()` is:

```
-type node_ret() ::
    {ok, [token()], [comment()], state()}
    | {error, {erl_anno:location(), module(), term()}, erl_anno:location()}
    | {eof, erl_anno:location()}.
```

and here `token()` refers to `erlfmt_scan:token()`