### PR TITLE
spec_clause body is always a single element

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -692,7 +692,7 @@ clause_has_break({clause, _Meta, empty, Guards, [Body | _]}) ->
     has_break_between(Guards, Body);
 clause_has_break({clause, _Meta, Head, _Guards, [Body | _]}) ->
     has_break_between(Head, Body);
-clause_has_break({spec_clause, _Meta, Head, [Body], _Guards}) ->
+clause_has_break({spec_clause, _Meta, Head, Body, _Guards}) ->
     has_break_between(Head, Body);
 clause_has_break({macro_call, _Meta, _Name, _Args}) ->
     false.
@@ -724,14 +724,14 @@ clause_to_algebra({clause, Meta, Head, Guards, Body}) ->
         group(concat(Nested(GuardsD), break(<<" ">>), <<"->">>)),
         Nested(BodyD)
     );
-clause_to_algebra({spec_clause, _Meta, Head, [Body], empty}) ->
+clause_to_algebra({spec_clause, _Meta, Head, Body, empty}) ->
     HeadD = clause_head_to_algebra(Head),
     BodyD = expr_to_algebra(Body),
     concat(
         space(HeadD, <<"->">>),
         group(nest(concat(break(<<" ">>), BodyD), ?INDENT))
     );
-clause_to_algebra({spec_clause, _Meta, Head, [Body], Guards}) ->
+clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     HeadD = clause_head_to_algebra(Head),
     GuardsD = spec_clause_gaurds_to_algebra(Guards),
     BodyD = expr_to_algebra(Body),

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -116,11 +116,11 @@ type_sigs -> type_sig ';' type_sigs : {['$1' | ?val('$3')], ?anno('$3')}.
 
 type_sig -> type_argument_list '->' type :
     Head = {args, ?anno('$1'), ?val('$1')},
-    {spec_clause, ?range_anno('$1', '$3'), Head, ['$3'], empty}.
+    {spec_clause, ?range_anno('$1', '$3'), Head, '$3', empty}.
 type_sig -> type_argument_list '->' type 'when' anno_types :
     Head = {args, ?anno('$1'), ?val('$1')},
     Guard = {guard_or, ?anno('$5'), [{guard_and, ?anno('$5'), ?val('$5')}]},
-    {spec_clause, ?range_anno('$1', '$5'), Head, ['$3'], Guard}.
+    {spec_clause, ?range_anno('$1', '$5'), Head, '$3', Guard}.
 
 type -> type '::' type : ?mkop2('$1', '$2', '$3').
 type -> type '|' type : ?mkop2('$1', '$2', '$3').

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -129,11 +129,11 @@ insert_nested({cons, Meta, Head0, Tail0}, Comments0) ->
     {{cons, Meta, Head, Tail}, Comments};
 insert_nested({spec_clause, Meta, Head0, Body0, empty}, Comments0) ->
     {Head, Comments1} = insert_expr(Head0, Comments0),
-    {Body, Comments} = insert_expr_list(Body0, Comments1),
+    {Body, Comments} = insert_expr(Body0, Comments1),
     {{spec_clause, Meta, Head, Body, empty}, Comments};
 insert_nested({spec_clause, Meta, Head0, Body0, Guards0}, Comments0) ->
     {Head, Comments1} = insert_expr(Head0, Comments0),
-    {Body, Comments2} = insert_expr_list(Body0, Comments1),
+    {Body, Comments2} = insert_expr(Body0, Comments1),
     {Guards, Comments} = insert_expr(Guards0, Comments2),
     {{spec_clause, Meta, Head, Body, Guards}, Comments};
 insert_nested({clause, Meta, Head0, empty, Body0}, Comments0) ->

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -287,7 +287,7 @@ specs(Config) when is_list(Config) ->
     ?assertMatch(
         {attribute, _, {atom, _, spec}, [
             {spec, _, {remote, _, {atom, _, foo}, {atom, _, bar}}, [
-                {spec_clause, _, {args, _, []}, [{atom, _, ok}], empty}
+                {spec_clause, _, {args, _, []}, {atom, _, ok}, empty}
             ]}
         ]},
         parse_form("-spec foo:bar() -> ok.")
@@ -296,8 +296,8 @@ specs(Config) when is_list(Config) ->
         {attribute, _, {atom, _, spec}, [
             {spec, _, {atom, _, foo}, [
                 {spec_clause, _, {args, _, [{call, _, {atom, _, integer}, []}]},
-                    [{atom, _, integer}], empty},
-                {spec_clause, _, {args, _, [{call, _, {atom, _, atom}, []}]}, [{atom, _, atom}],
+                    {atom, _, integer}, empty},
+                {spec_clause, _, {args, _, [{call, _, {atom, _, atom}, []}]}, {atom, _, atom},
                     empty}
             ]}
         ]},
@@ -306,7 +306,7 @@ specs(Config) when is_list(Config) ->
     ?assertMatch(
         {attribute, _, {atom, _, callback}, [
             {spec, _, {atom, _, foo}, [
-                {spec_clause, _, {args, _, [{var, _, 'X'}]}, [{var, _, 'Y'}],
+                {spec_clause, _, {args, _, [{var, _, 'X'}]}, {var, _, 'Y'},
                     {guard_or, _, [
                         {guard_and, _, [
                             {op, _, '::', {var, _, 'X'}, {call, _, {atom, _, integer}, []}},
@@ -320,7 +320,7 @@ specs(Config) when is_list(Config) ->
     ?assertMatch(
         {attribute, _, {atom, _, spec}, [
             {spec, _, {macro_call, _, {atom, _, foo}, none}, [
-                {spec_clause, _, {args, _, []}, [{atom, _, ok}], empty}
+                {spec_clause, _, {args, _, []}, {atom, _, ok}, empty}
             ]}
         ]},
         parse_form("-spec ?foo() -> ok.")
@@ -328,7 +328,7 @@ specs(Config) when is_list(Config) ->
     ?assertMatch(
         {attribute, _, {atom, _, callback}, [
             {spec, _, {macro_call, _, {var, _, 'FOO'}, none}, [
-                {spec_clause, _, {args, _, []}, [{atom, _, ok}], empty}
+                {spec_clause, _, {args, _, []}, {atom, _, ok}, empty}
             ]}
         ]},
         parse_form("-callback ?FOO() -> ok.")

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -295,8 +295,8 @@ specs(Config) when is_list(Config) ->
     ?assertMatch(
         {attribute, _, {atom, _, spec}, [
             {spec, _, {atom, _, foo}, [
-                {spec_clause, _, {args, _, [{call, _, {atom, _, integer}, []}]},
-                    {atom, _, integer}, empty},
+                {spec_clause, _, {args, _, [{call, _, {atom, _, integer}, []}]}, {atom, _, integer},
+                    empty},
                 {spec_clause, _, {args, _, [{call, _, {atom, _, atom}, []}]}, {atom, _, atom},
                     empty}
             ]}

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -3256,6 +3256,88 @@ spec(Config) when is_list(Config) ->
         "        {VeryLongTuple,\n"
         "            EvenLonger}.\n",
         30
+    ),
+    ?assertSame(
+        "-spec foo(Int) -> atom() when\n"
+        "    %% comment\n"
+        "    Int :: integer().\n"
+    ),
+    ?assertFormat(
+        "-spec foo(Int) -> atom() when\n"
+        "    Int :: integer()\n"
+        "    %% after clause comment\n"
+        "    .\n",
+        "-spec foo(Int) -> atom() when Int :: integer()\n"
+        "%% after clause comment\n"
+        ".\n"
+    ),
+    ?assertFormat(
+        "-spec foo(Int) -> atom()\n"
+        "    %% before when comment\n"
+        "    when Int :: integer().\n",
+        "-spec foo(Int) -> atom() when\n"
+        "    %% before when comment\n"
+        "    Int :: integer().\n"
+    ),
+    ?assertFormat(
+        "-spec foo(Int) -> atom()\n"
+        "    %% before when comment\n"
+        "    when\n"
+        "    %% after when comment\n"
+        "    Int :: integer().\n",
+        "-spec foo(Int) -> atom() when\n"
+        "    %% before when comment\n"
+        "\n"
+        "    %% after when comment\n"
+        "    Int :: integer().\n"
+    ),
+    ?assertFormat(
+        "-spec to_atom\n"
+        "    %% int to atom\n"
+        "    (Int) -> atom() when\n"
+        "    %% int is integer\n"
+        "    Int :: integer();\n"
+        "    %% string to atom\n"
+        "    (String) -> atom() when\n"
+        "    %% string is string\n"
+        "    String :: string().\n",
+        "-spec to_atom\n"
+        "    %% int to atom\n"
+        "    (Int) -> atom() when\n"
+        "        %% int is integer\n"
+        "        Int :: integer();\n"
+        "    %% string to atom\n"
+        "    (String) -> atom() when\n"
+        "        %% string is string\n"
+        "        String :: string().\n"
+    ),
+    ?assertFormat(
+        "-spec to_atom\n"
+        "    %% int to atom\n"
+        "    (Int) -> atom() when\n"
+        "    %% int is integer\n"
+        "    Int :: integer()\n"
+        "    %% before semi colon\n"
+        "    ;\n"
+        "    %% string to atom\n"
+        "    (String) -> atom() when\n"
+        "    %% string is string\n"
+        "    String :: string()\n"
+        "    %% before dot\n"
+        "    .\n",
+        "-spec to_atom\n"
+        "    %% int to atom\n"
+        "    (Int) -> atom() when\n"
+        "        %% int is integer\n"
+        "        Int :: integer();\n"
+        "    %% before semi colon\n"
+        "\n"
+        "    %% string to atom\n"
+        "    (String) -> atom() when\n"
+        "        %% string is string\n"
+        "        String :: string()\n"
+        "%% before dot\n"
+        ".\n"
     ).
 
 define(Config) when is_list(Config) ->


### PR DESCRIPTION
Removes `insert_expr_list` for `spec_clause`, since it always has a single body element.
This partially addresses https://github.com/WhatsApp/erlfmt/issues/125

I have also added tests to showcase that sometimes comments move before a `;` and to after a `when`, but I think these moves are in the acceptable range.