### PR TITLE
Preserve comments in receive after after

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -796,8 +796,8 @@ receive_after_to_algebra(Expr, [HBody | _] = Body) ->
                     <<"after">>,
                     line(),
                     ExprD,
-                    <<" ->">>,
-                    nest(concat(break(<<"">>), BodyD), ?INDENT, always)
+                    <<" -> ">>,
+                    nest(BodyD, ?INDENT, break)
                 ])
         end,
     group(nest(Doc, ?INDENT)).

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -780,27 +780,10 @@ single_clause_spec_to_algebra(Name, {spec_clause, CMeta, Head, Body, Guards}) ->
 receive_after_to_algebra(Expr, [HBody | _] = Body) ->
     ExprD = expr_to_algebra(Expr),
     BodyD = block_to_algebra(Body),
-    Doc =
-        case comments(Expr) of
-            {[], []} ->
-                concat([
-                    <<"after ">>,
-                    ExprD,
-                    <<" ->">>,
-                    break(),
-                    maybe_force_breaks(has_break_between(Expr, HBody)),
-                    BodyD
-                ]);
-            _ ->
-                concat([
-                    <<"after">>,
-                    line(),
-                    ExprD,
-                    <<" -> ">>,
-                    BodyD
-                ])
-        end,
-    group(nest(Doc, ?INDENT)).
+    MaybeForce = maybe_force_breaks(has_break_between(Expr, HBody)),
+    HeadD = group(concat([<<"after">>, break(), ExprD, <<" ">>])),
+    Doc = nest(concat([<<"->">>, break(), MaybeForce, BodyD]), ?INDENT),
+    group(concat(HeadD, Doc)).
 
 try_to_algebra(Body, OfClauses, CatchClauses, After) ->
     Clauses =

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -783,11 +783,13 @@ receive_after_to_algebra(Expr, Body) ->
     Nest = fun(List) -> group(nest(concat(List), ?INDENT, break)) end,
     case comments(Expr) of
         {[], []} ->
+            MaybeForceBreaks = maybe_force_breaks(has_break_between(Expr, Body)),
             concat([
                 <<"after ">>,
                 ExprD,
                 <<" ->">>,
                 Nest([
+                    MaybeForceBreaks,
                     break(),
                     BodyD
                 ])

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -797,7 +797,7 @@ receive_after_to_algebra(Expr, [HBody | _] = Body) ->
                     line(),
                     ExprD,
                     <<" -> ">>,
-                    nest(BodyD, ?INDENT, break)
+                    BodyD
                 ])
         end,
     group(nest(Doc, ?INDENT)).

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -781,18 +781,31 @@ receive_after_to_algebra(Expr, Body) ->
     ExprD = expr_to_algebra(Expr),
     BodyD = block_to_algebra(Body),
     Nest = fun(List) -> group(nest(concat(List), ?INDENT, break)) end,
-    concat([
-        <<"after">>,
-        Nest([
-            break(),
-            ExprD,
-            <<" ->">>,
-            Nest([
-                break(),
-                BodyD
+    case comments(Expr) of
+        {[], []} ->
+            concat([
+                <<"after ">>,
+                ExprD,
+                <<" ->">>,
+                Nest([
+                    break(),
+                    BodyD
+                ])
+            ]);
+        _ ->
+            concat([
+                <<"after">>,
+                Nest([
+                    break(),
+                    ExprD,
+                    <<" ->">>,
+                    Nest([
+                        break(),
+                        BodyD
+                    ])
+                ])
             ])
-        ])
-    ]).
+    end.
 
 try_to_algebra(Body, OfClauses, CatchClauses, After) ->
     Clauses =

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -780,12 +780,26 @@ single_clause_spec_to_algebra(Name, {spec_clause, CMeta, Head, Body, Guards}) ->
 receive_after_to_algebra(Expr, [HBody | _] = Body) ->
     ExprD = expr_to_algebra(Expr),
     BodyD = block_to_algebra(Body),
-    HeadD = case comments(Expr) of
-        {[], []} -> concat([<<"after ">>, ExprD, <<" ->">>]);
-        _ ->
-            concat([<<"after">>, line(), ExprD, <<" ->">>])
-    end,
-    Doc = concat([HeadD, break(), maybe_force_breaks(has_break_between(Expr, HBody)), BodyD]),
+    Doc =
+        case comments(Expr) of
+            {[], []} ->
+                concat([
+                    <<"after ">>,
+                    ExprD,
+                    <<" ->">>,
+                    break(),
+                    maybe_force_breaks(has_break_between(Expr, HBody)),
+                    BodyD
+                ]);
+            _ ->
+                concat([
+                    <<"after">>,
+                    line(),
+                    ExprD,
+                    <<" ->">>,
+                    nest(concat(break(<<"">>), BodyD), ?INDENT, always)
+                ])
+        end,
     group(nest(Doc, ?INDENT)).
 
 try_to_algebra(Body, OfClauses, CatchClauses, After) ->

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -397,11 +397,15 @@ cr_clause -> expr clause_guard clause_body :
     {clause, ?range_anno('$1', '$3'), '$1', '$2', ?val('$3')}.
 
 receive_expr -> 'receive' cr_clauses 'end' :
-        {'receive',?range_anno('$1', '$3'),'$2'}.
-receive_expr -> 'receive' 'after' expr clause_body 'end' :
-        {'receive',?range_anno('$1', '$5'),[],'$3',?val('$4')}.
-receive_expr -> 'receive' cr_clauses 'after' expr clause_body 'end' :
-        {'receive',?range_anno('$1', '$6'),'$2','$4',?val('$5')}.
+        Clauses = {clauses, ?range_anno('$1', '$3'), '$2'},
+        {'receive',?range_anno('$1', '$3'),Clauses}.
+receive_expr -> 'receive' 'after' expr clause_body 'end':
+        After =  {after_clause, ?range_anno('$2', '$5'), '$3', ?val('$4')},
+        {'receive',?range_anno('$1', '$5'),empty,After}.
+receive_expr -> 'receive' cr_clauses 'after' expr clause_body 'end':
+        After =  {after_clause, ?range_anno('$3', '$6'), '$4', ?val('$5')},
+        Clauses = {clauses, ?range_upto_anno('$1', '$3'), '$2'},
+        {'receive',?range_anno('$1', '$6'),Clauses,After}.
 
 fun_expr -> 'fun' atom_or_var_or_macro '/' integer_or_var_or_macro :
     Anno = ?range_anno('$1', '$4'),

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -219,7 +219,7 @@ insert_nested({'case', Meta, Expr0, Clauses0}, Comments0) ->
 insert_nested({'receive', Meta, Clauses0}, Comments0) ->
     {Clauses, []} = insert_expr(Clauses0, Comments0),
     {{'receive', Meta, Clauses}, []};
-insert_nested({'receive', Meta, empty, {after_clause, _, _, _} = After0}, Comments0) ->
+insert_nested({'receive', Meta, empty, After0}, Comments0) ->
     {After, []} = insert_expr(After0, Comments0),
     {{'receive', Meta, empty, After}, []};
 insert_nested({'receive', Meta, Clauses0, After0}, Comments0) ->

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -217,13 +217,19 @@ insert_nested({'case', Meta, Expr0, Clauses0}, Comments0) ->
     Clauses = insert_expr_container(Clauses0, Comments1),
     {{'case', Meta, Expr, Clauses}, []};
 insert_nested({'receive', Meta, Clauses0}, Comments0) ->
-    Clauses = insert_expr_container(Clauses0, Comments0),
+    {Clauses, []} = insert_expr(Clauses0, Comments0),
     {{'receive', Meta, Clauses}, []};
-insert_nested({'receive', Meta, Clauses0, AfterExpr0, AfterBody0}, Comments0) ->
-    {Clauses, Comments1} = insert_expr_list(Clauses0, Comments0),
-    {AfterExpr, Comments2} = insert_expr(AfterExpr0, Comments1),
-    AfterBody = insert_expr_container(AfterBody0, Comments2),
-    {{'receive', Meta, Clauses, AfterExpr, AfterBody}, []};
+insert_nested({'receive', Meta, empty, {after_clause, _, _, _} = After0}, Comments0) ->
+    {After, []} = insert_expr(After0, Comments0),
+    {{'receive', Meta, empty, After}, []};
+insert_nested({'receive', Meta, Clauses0, After0}, Comments0) ->
+    {Clauses, Comments1} = insert_expr(Clauses0, Comments0),
+    {After, []} = insert_expr(After0, Comments1),
+    {{'receive', Meta, Clauses, After}, []};
+insert_nested({after_clause, Meta, Expr0, Body0}, Comments0) ->
+    {Expr, Comments1} = insert_expr(Expr0, Comments0),
+    Body = insert_expr_container(Body0, Comments1),
+    {{after_clause, Meta, Expr, Body}, []};
 insert_nested({'if', Meta, Clauses0}, Comments0) ->
     Clauses = insert_expr_container(Clauses0, Comments0),
     {{'if', Meta, Clauses}, []};

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -728,7 +728,7 @@ clauses(Config) when is_list(Config) ->
         parse_expr("case X of true -> ok end")
     ),
     ?assertMatch(
-        {'receive', _, [{clause, _, {var, _, '_'}, empty, [{atom, _, true}]}]},
+        {'receive', _, {clauses, _, [{clause, _, {var, _, '_'}, empty, [{atom, _, true}]}]}},
         parse_expr("receive _ -> true end")
     ),
     ?assertMatch(

--- a/test/erlfmt_SUITE_data/simple_comments.erl
+++ b/test/erlfmt_SUITE_data/simple_comments.erl
@@ -161,11 +161,10 @@ call() ->
     receive
         ok -> ok
         %% comment 5
-    after
-        1 ->
-            %% comment 6
-            ok
-            %% comment 7
+    after 1 ->
+        %% comment 6
+        ok
+        %% comment 7
     end.
 
 'if'() ->

--- a/test/erlfmt_SUITE_data/simple_comments.erl
+++ b/test/erlfmt_SUITE_data/simple_comments.erl
@@ -160,7 +160,7 @@ call() ->
     end,
     receive
         ok -> ok
-    %% comment 5
+        %% comment 5
     after 1 ->
         %% comment 6
         ok

--- a/test/erlfmt_SUITE_data/simple_comments.erl
+++ b/test/erlfmt_SUITE_data/simple_comments.erl
@@ -161,10 +161,11 @@ call() ->
     receive
         ok -> ok
         %% comment 5
-    after 1 ->
-        %% comment 6
-        ok
-        %% comment 7
+    after
+        1 ->
+            %% comment 6
+            ok
+            %% comment 7
     end.
 
 'if'() ->

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2479,11 +2479,10 @@ receive_expression(Config) when is_list(Config) ->
     ),
     ?assertSame(
         "receive\n"
-        "after\n"
-        "    0 ->\n"
-        "        some:long(\n"
-        "            Expression\n"
-        "        )\n"
+        "after 0 ->\n"
+        "    some:long(\n"
+        "        Expression\n"
+        "    )\n"
         "end\n",
         25
     ),
@@ -2588,10 +2587,9 @@ receive_expression(Config) when is_list(Config) ->
         "    % receive post comment\n"
         "end\n",
         "receive\n"
-        "after\n"
-        "    0 ->\n"
-        "        ok\n"
-        "        % receive post comment\n"
+        "after 0 ->\n"
+        "    ok\n"
+        "    % receive post comment\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2633,10 +2631,9 @@ receive_expression(Config) when is_list(Config) ->
         "receive\n"
         "    1 -> ok\n"
         "    %% after receive\n"
-        "after\n"
-        "    0 ->\n"
-        "        ok\n"
-        "        %% after after for receive\n"
+        "after 0 ->\n"
+        "    ok\n"
+        "    %% after after for receive\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2661,20 +2658,20 @@ receive_expression(Config) when is_list(Config) ->
     ?assertFormat(
         "receive\n"
         "    1 -> ok\n"
-        "after\n"
-        "    0 -> a(\n"
+        "after 0 -> % after arrow moves one line above\n"
+        "    a(\n"
         "        b,\n"
         "        c\n"
         "    )\n"
         "end\n",
         "receive\n"
         "    1 -> ok\n"
-        "after\n"
-        "    0 ->\n"
-        "        a(\n"
-        "            b,\n"
-        "            c\n"
-        "        )\n"
+        "    % after arrow moves one line above\n"
+        "after 0 ->\n"
+        "    a(\n"
+        "        b,\n"
+        "        c\n"
+        "    )\n"
         "end\n"
     ),
     ?assertFormat(

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2479,8 +2479,11 @@ receive_expression(Config) when is_list(Config) ->
     ),
     ?assertSame(
         "receive\n"
-        "after 0 ->\n"
-        "    some:long(Expression)\n"
+        "after\n"
+        "    0 ->\n"
+        "        some:long(\n"
+        "            Expression\n"
+        "        )\n"
         "end\n",
         25
     ),
@@ -2490,11 +2493,15 @@ receive_expression(Config) when is_list(Config) ->
         "after 0 -> ok\n"
         "end\n"
     ),
-    ?assertSame(
+    ?assertFormat(
         "receive\n"
         "    1 -> ok\n"
         "after 0 ->\n"
         "    ok\n"
+        "end\n",
+        "receive\n"
+        "    1 -> ok\n"
+        "after 0 -> ok\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2581,9 +2588,10 @@ receive_expression(Config) when is_list(Config) ->
         "    % receive post comment\n"
         "end\n",
         "receive\n"
-        "after 0 ->\n"
-        "    ok\n"
-        "    % receive post comment\n"
+        "after\n"
+        "    0 ->\n"
+        "        ok\n"
+        "        % receive post comment\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2594,9 +2602,8 @@ receive_expression(Config) when is_list(Config) ->
         "end\n",
         "receive\n"
         "after\n"
-        "% before zero\n"
-        "0 ->\n"
-        "    ok\n"
+        "    % before zero\n"
+        "    0 -> ok\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2609,10 +2616,10 @@ receive_expression(Config) when is_list(Config) ->
         "end.\n",
         "receive\n"
         "after\n"
-        "%% foo\n"
-        "0 ->\n"
-        "    \"abc\"\n"
-        "    \"def\"\n"
+        "    %% foo\n"
+        "    0 ->\n"
+        "        \"abc\"\n"
+        "        \"def\"\n"
         "end.\n"
     ),
     ?assertFormat(
@@ -2626,9 +2633,10 @@ receive_expression(Config) when is_list(Config) ->
         "receive\n"
         "    1 -> ok\n"
         "    %% after receive\n"
-        "after 0 ->\n"
-        "    ok\n"
-        "    %% after after for receive\n"
+        "after\n"
+        "    0 ->\n"
+        "        ok\n"
+        "        %% after after for receive\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2644,10 +2652,10 @@ receive_expression(Config) when is_list(Config) ->
         "    1 -> ok\n"
         "    %% after receive\n"
         "after\n"
-        "%% before zero\n"
-        "0 ->\n"
-        "    ok\n"
-        "    %% after after for receive\n"
+        "    %% before zero\n"
+        "    0 ->\n"
+        "        ok\n"
+        "        %% after after for receive\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2666,13 +2674,13 @@ receive_expression(Config) when is_list(Config) ->
         "    1 -> ok\n"
         "    %% after receive\n"
         "after\n"
-        "%% before zero\n"
-        "0 ->\n"
-        "    a(\n"
-        "        b,\n"
-        "        c\n"
-        "    )\n"
-        "    %% after after for receive\n"
+        "    %% before zero\n"
+        "    0 ->\n"
+        "        a(\n"
+        "            b,\n"
+        "            c\n"
+        "        )\n"
+        "        %% after after for receive\n"
         "end\n"
     ).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2588,6 +2588,19 @@ receive_expression(Config) when is_list(Config) ->
     ),
     ?assertFormat(
         "receive\n"
+        "after\n"
+        "    % before zero\n"
+        "    0 -> ok\n"
+        "end\n",
+        "receive\n"
+        "after\n"
+        "    % before zero\n"
+        "    0 ->\n"
+        "    ok\n"
+        "end\n"
+    ),
+    ?assertFormat(
+        "receive\n"
         "    1 -> ok\n"
         "    %% after receive\n"
         "after\n"
@@ -2596,23 +2609,29 @@ receive_expression(Config) when is_list(Config) ->
         "end\n",
         "receive\n"
         "    1 -> ok\n"
-        "%% after receive\n"
-        "\n"
+        "    %% after receive\n"
         "after 0 ->\n"
         "    ok\n"
         "    %% after after for receive\n"
         "end\n"
     ),
-    %% TODO: We do not want this comment to move
     ?assertFormat(
         "receive\n"
+        "    1 -> ok\n"
+        "    %% after receive\n"
         "after\n"
-        "    % before zero\n"
+        "    %% before zero\n"
         "    0 -> ok\n"
+        "    %% after after for receive\n"
         "end\n",
         "receive\n"
-        "% before zero\n"
-        "after 0 -> ok\n"
+        "    1 -> ok\n"
+        "    %% after receive\n"
+        "after\n"
+        "    %% before zero\n"
+        "    0 ->\n"
+        "    ok\n"
+        "    %% after after for receive\n"
         "end\n"
     ).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2586,19 +2586,32 @@ receive_expression(Config) when is_list(Config) ->
         "    % receive post comment\n"
         "end\n"
     ),
-    ?assertSame(
+    ?assertFormat(
         "receive\n"
         "after\n"
         "    % before zero\n"
         "    0 -> ok\n"
+        "end\n",
+        "receive\n"
+        "after\n"
+        "% before zero\n"
+        "0 ->\n"
+        "    ok\n"
         "end\n"
     ),
-    %% TODO: This is not correct, concat needs to be indented
-    ?assertSame(
+    ?assertFormat(
         "receive\n"
         "after\n"
         "    %% foo\n"
-        "    0 -> \"abc\"\n"
+        "    0 ->\n"
+        "        \"abc\"\n"
+        "        \"def\"\n"
+        "end.\n",
+        "receive\n"
+        "after\n"
+        "%% foo\n"
+        "0 ->\n"
+        "    \"abc\"\n"
         "    \"def\"\n"
         "end.\n"
     ),
@@ -2631,8 +2644,9 @@ receive_expression(Config) when is_list(Config) ->
         "    1 -> ok\n"
         "    %% after receive\n"
         "after\n"
-        "    %% before zero\n"
-        "    0 -> ok\n"
+        "%% before zero\n"
+        "0 ->\n"
+        "    ok\n"
         "    %% after after for receive\n"
         "end\n"
     ),
@@ -2652,8 +2666,9 @@ receive_expression(Config) when is_list(Config) ->
         "    1 -> ok\n"
         "    %% after receive\n"
         "after\n"
-        "    %% before zero\n"
-        "    0 -> a(\n"
+        "%% before zero\n"
+        "0 ->\n"
+        "    a(\n"
         "        b,\n"
         "        c\n"
         "    )\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2629,7 +2629,7 @@ receive_expression(Config) when is_list(Config) ->
         "after\n"
         "    %% before zero\n"
         "    0 -> ok\n"
-        "        %% after after for receive\n"
+        "    %% after after for receive\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2650,10 +2650,10 @@ receive_expression(Config) when is_list(Config) ->
         "after\n"
         "    %% before zero\n"
         "    0 -> a(\n"
-        "            b,\n"
-        "            c\n"
-        "        )\n"
-        "        %% after after for receive\n"
+        "        b,\n"
+        "        c\n"
+        "    )\n"
+        "    %% after after for receive\n"
         "end\n"
     ).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2574,13 +2574,18 @@ receive_expression(Config) when is_list(Config) ->
         "    2 -> two\n"
         "end\n"
     ),
-    % ?assertSame(
-    %     "receive\n"
-    %     "after\n"
-    %     "    % foo\n"
-    %     "    0 -> ok\n"
-    %     "end\n"
-    % ),
+    ?assertFormat(
+        "receive\n"
+        "after\n"
+        "    0 -> ok\n"
+        "    % receive post comment\n"
+        "end\n",
+        "receive\n"
+        "after 0 ->\n"
+        "    ok\n"
+        "    % receive post comment\n"
+        "end\n"
+    ),
     ?assertFormat(
         "receive\n"
         "    1 -> ok\n"
@@ -2596,6 +2601,18 @@ receive_expression(Config) when is_list(Config) ->
         "after 0 ->\n"
         "    ok\n"
         "    %% after after for receive\n"
+        "end\n"
+    ),
+    %% TODO: We do not want this comment to move
+    ?assertFormat(
+        "receive\n"
+        "after\n"
+        "    % before zero\n"
+        "    0 -> ok\n"
+        "end\n",
+        "receive\n"
+        "% before zero\n"
+        "after 0 -> ok\n"
         "end\n"
     ).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2661,6 +2661,25 @@ receive_expression(Config) when is_list(Config) ->
     ?assertFormat(
         "receive\n"
         "    1 -> ok\n"
+        "after\n"
+        "    0 -> a(\n"
+        "        b,\n"
+        "        c\n"
+        "    )\n"
+        "end\n",
+        "receive\n"
+        "    1 -> ok\n"
+        "after\n"
+        "    0 ->\n"
+        "        a(\n"
+        "            b,\n"
+        "            c\n"
+        "        )\n"
+        "end\n"
+    ),
+    ?assertFormat(
+        "receive\n"
+        "    1 -> ok\n"
         "    %% after receive\n"
         "after\n"
         "    %% before zero\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2492,15 +2492,11 @@ receive_expression(Config) when is_list(Config) ->
         "after 0 -> ok\n"
         "end\n"
     ),
-    ?assertFormat(
+    ?assertSame(
         "receive\n"
         "    1 -> ok\n"
         "after 0 ->\n"
         "    ok\n"
-        "end\n",
-        "receive\n"
-        "    1 -> ok\n"
-        "after 0 -> ok\n"
         "end\n"
     ),
     ?assertFormat(

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2596,7 +2596,7 @@ receive_expression(Config) when is_list(Config) ->
         "after\n"
         "    % before zero\n"
         "    0 ->\n"
-        "    ok\n"
+        "        ok\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2630,8 +2630,8 @@ receive_expression(Config) when is_list(Config) ->
         "after\n"
         "    %% before zero\n"
         "    0 ->\n"
-        "    ok\n"
-        "    %% after after for receive\n"
+        "        ok\n"
+        "        %% after after for receive\n"
         "end\n"
     ).
 

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2586,17 +2586,21 @@ receive_expression(Config) when is_list(Config) ->
         "    % receive post comment\n"
         "end\n"
     ),
-    ?assertFormat(
-        "receive\n"
-        "after\n"
-        "    % before zero\n"
-        "    0 -> ok\n"
-        "end\n",
+    ?assertSame(
         "receive\n"
         "after\n"
         "    % before zero\n"
         "    0 -> ok\n"
         "end\n"
+    ),
+    %% TODO: This is not correct, concat needs to be indented
+    ?assertSame(
+        "receive\n"
+        "after\n"
+        "    %% foo\n"
+        "    0 -> \"abc\"\n"
+        "    \"def\"\n"
+        "end.\n"
     ),
     ?assertFormat(
         "receive\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2595,8 +2595,7 @@ receive_expression(Config) when is_list(Config) ->
         "receive\n"
         "after\n"
         "    % before zero\n"
-        "    0 ->\n"
-        "        ok\n"
+        "    0 -> ok\n"
         "end\n"
     ),
     ?assertFormat(
@@ -2629,8 +2628,31 @@ receive_expression(Config) when is_list(Config) ->
         "    %% after receive\n"
         "after\n"
         "    %% before zero\n"
-        "    0 ->\n"
-        "        ok\n"
+        "    0 -> ok\n"
+        "        %% after after for receive\n"
+        "end\n"
+    ),
+    ?assertFormat(
+        "receive\n"
+        "    1 -> ok\n"
+        "    %% after receive\n"
+        "after\n"
+        "    %% before zero\n"
+        "    0 -> a(\n"
+        "        b,\n"
+        "        c\n"
+        "    )\n"
+        "    %% after after for receive\n"
+        "end\n",
+        "receive\n"
+        "    1 -> ok\n"
+        "    %% after receive\n"
+        "after\n"
+        "    %% before zero\n"
+        "    0 -> a(\n"
+        "            b,\n"
+        "            c\n"
+        "        )\n"
         "        %% after after for receive\n"
         "end\n"
     ).


### PR DESCRIPTION
Fixes https://github.com/WhatsApp/erlfmt/issues/125

Before this diff the following test would have passed where the comment is moved from before the `after` to above the `after`

```erlang
?assertFormat(
        "receive\n"
        "after\n"
        "    % before zero\n"
        "    0 -> ok\n"
        "end\n",
        "receive\n"
        "% before zero\n"
        "after 0 -> ok\n"
        "end\n"
    ),
```