### PR TITLE
preserve newline in spec without guards

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -722,12 +722,14 @@ clause_to_algebra({clause, Meta, Head, Guards, Body}) ->
     GuardsD = expr_to_algebra(Guards),
     BodyD = block_to_algebra(Meta, Body),
     MaybeForceHeadGuards = maybe_force_breaks(has_break_between(Head, Guards)),
+    MaybeForceGuardsBody = maybe_force_breaks(has_break_between(Guards, Body)),
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
     concat(
         space(HeadD, <<"when">>),
         group(
             concat(
                 group(concat([MaybeForceHeadGuards, Nested(GuardsD), break(<<" ">>), <<"->">>])),
+                MaybeForceGuardsBody,
                 Nested(BodyD)
             )
         )
@@ -737,12 +739,14 @@ clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     GuardsD = spec_clause_gaurds_to_algebra(Guards),
     BodyD = expr_to_algebra(Body),
     MaybeForceHeadBody = maybe_force_breaks(has_break_between(Head, Body)),
+    MaybeForceBodyGuards = maybe_force_breaks(has_break_between(Body, Guards)),
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
     concat(
         space(HeadD, <<"->">>),
         group(
             concat(
                 group(concat([MaybeForceHeadBody, Nested(BodyD), break(<<" ">>), <<"when">>])),
+                MaybeForceBodyGuards,
                 Nested(GuardsD)
             )
         )

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -724,10 +724,12 @@ clause_to_algebra({clause, Meta, Head, Guards, Body}) ->
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
     concat(
         space(HeadD, <<"when">>),
-        group(concat(
-            group(concat(Nested(GuardsD), break(<<" ">>), <<"->">>)),
-            Nested(BodyD)
-        ))
+        group(
+            concat(
+                group(concat(Nested(GuardsD), break(<<" ">>), <<"->">>)),
+                Nested(BodyD)
+            )
+        )
     );
 clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     HeadD = clause_head_to_algebra(Head),
@@ -736,10 +738,12 @@ clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
     concat(
         space(HeadD, <<"->">>),
-        group(concat(
-            group(concat(Nested(BodyD), break(<<" ">>), <<"when">>)),
-            Nested(GuardsD)
-        ))
+        group(
+            concat(
+                group(concat(Nested(BodyD), break(<<" ">>), <<"when">>)),
+                Nested(GuardsD)
+            )
+        )
     ).
 
 clause_head_to_algebra({op, Meta, Op, Left, Right}) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -724,15 +724,10 @@ clause_to_algebra({clause, Meta, Head, Guards, Body}) ->
     MaybeForceHeadGuards = maybe_force_breaks(has_break_between(Head, Guards)),
     MaybeForceGuardsBody = maybe_force_breaks(has_break_between(Guards, Body)),
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
+    GuardsArrowD = group(concat([MaybeForceHeadGuards, Nested(GuardsD), break(<<" ">>), <<"->">>])),
     concat(
         space(HeadD, <<"when">>),
-        group(
-            concat(
-                group(concat([MaybeForceHeadGuards, Nested(GuardsD), break(<<" ">>), <<"->">>])),
-                MaybeForceGuardsBody,
-                Nested(BodyD)
-            )
-        )
+        group(concat(GuardsArrowD, MaybeForceGuardsBody, Nested(BodyD)))
     );
 clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     HeadD = clause_head_to_algebra(Head),
@@ -741,15 +736,10 @@ clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     MaybeForceHeadBody = maybe_force_breaks(has_break_between(Head, Body)),
     MaybeForceBodyGuards = maybe_force_breaks(has_break_between(Body, Guards)),
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
+    BodyWhenD = group(concat([MaybeForceHeadBody, Nested(BodyD), break(<<" ">>), <<"when">>])),
     concat(
         space(HeadD, <<"->">>),
-        group(
-            concat(
-                group(concat([MaybeForceHeadBody, Nested(BodyD), break(<<" ">>), <<"when">>])),
-                MaybeForceBodyGuards,
-                Nested(GuardsD)
-            )
-        )
+        group(concat(BodyWhenD, MaybeForceBodyGuards, Nested(GuardsD)))
     ).
 
 clause_head_to_algebra({op, Meta, Op, Left, Right}) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -724,8 +724,10 @@ clause_to_algebra({clause, Meta, Head, Guards, Body}) ->
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
     concat(
         space(HeadD, <<"when">>),
-        group(concat(Nested(GuardsD), break(<<" ">>), <<"->">>)),
-        Nested(BodyD)
+        group(concat(
+            group(concat(Nested(GuardsD), break(<<" ">>), <<"->">>)),
+            Nested(BodyD)
+        ))
     );
 clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     HeadD = clause_head_to_algebra(Head),
@@ -734,8 +736,10 @@ clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
     concat(
         space(HeadD, <<"->">>),
-        group(concat(Nested(BodyD), break(<<" ">>), <<"when">>)),
-        Nested(GuardsD)
+        group(concat(
+            group(concat(Nested(BodyD), break(<<" ">>), <<"when">>)),
+            Nested(GuardsD)
+        ))
     ).
 
 clause_head_to_algebra({op, Meta, Op, Left, Right}) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -823,7 +823,7 @@ try_of_block(Body, OfClauses) ->
 is_multiline(Node) ->
     erlfmt_scan:get_inner_line(Node) =/= erlfmt_scan:get_inner_end_line(Node).
 
-has_break_between(Left, [Right | _ ]) ->
+has_break_between(Left, [Right | _]) ->
     has_break_between(Left, Right);
 has_break_between(Left, Right) ->
     erlfmt_scan:get_end_line(Left) < erlfmt_scan:get_line(Right).

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -709,6 +709,10 @@ clause_to_algebra({clause, _Meta, Head, empty, Body}) ->
     HeadD = clause_head_to_algebra(Head),
     BodyD = block_to_algebra(Body),
     space(HeadD, nest(break(<<"->">>, BodyD), ?INDENT));
+clause_to_algebra({spec_clause, _Meta, Head, Body, empty}) ->
+    HeadD = clause_head_to_algebra(Head),
+    BodyD = expr_to_algebra(Body),
+    space(HeadD, nest(break(<<"->">>, BodyD), ?INDENT));
 clause_to_algebra({clause, _Meta, empty, Guards, Body}) ->
     GuardsD = expr_to_algebra(Guards),
     BodyD = block_to_algebra(Body),
@@ -717,19 +721,11 @@ clause_to_algebra({clause, Meta, Head, Guards, Body}) ->
     HeadD = clause_head_to_algebra(Head),
     GuardsD = expr_to_algebra(Guards),
     BodyD = block_to_algebra(Meta, Body),
-
     Nested = fun(Doc) -> nest(concat(break(<<" ">>), Doc), ?INDENT) end,
     concat(
         space(HeadD, <<"when">>),
         group(concat(Nested(GuardsD), break(<<" ">>), <<"->">>)),
         Nested(BodyD)
-    );
-clause_to_algebra({spec_clause, _Meta, Head, Body, empty}) ->
-    HeadD = clause_head_to_algebra(Head),
-    BodyD = expr_to_algebra(Body),
-    concat(
-        space(HeadD, <<"->">>),
-        group(nest(concat(break(<<" ">>), BodyD), ?INDENT))
     );
 clause_to_algebra({spec_clause, _Meta, Head, Body, Guards}) ->
     HeadD = clause_head_to_algebra(Head),

--- a/test/erlfmt_SUITE_data/comments.erl.formatted
+++ b/test/erlfmt_SUITE_data/comments.erl.formatted
@@ -31,7 +31,9 @@ has_fanciness([]) ->
     false.
 
 %% comment
-bar(X) when is_list(X) ->
+bar(X) when
+    is_list(X)
+->
     ok;
 %% comment
 bar(X) when is_atom(X) ->

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -3115,6 +3115,10 @@ record_definition(Config) when is_list(Config) ->
     ).
 
 spec(Config) when is_list(Config) ->
+    ?assertSame(
+        "-spec foo() ->\n"
+        "    atom().\n"
+    ),
     ?assertFormat(
         "-spec child_spec(#{\n"
         "    name => {local, Name :: atom()} | {global, GlobalName :: any()} | {via, Module :: atom(), ViaName :: any()},\n"
@@ -3126,7 +3130,8 @@ spec(Config) when is_list(Config) ->
         "        | {global, GlobalName :: any()}\n"
         "        | {via, Module :: atom(), ViaName :: any()},\n"
         "    another_field => atom()\n"
-        "}) -> supervisor:child_spec().\n"
+        "}) ->\n"
+        "    supervisor:child_spec().\n"
     ),
     ?assertSame(
         "-spec foo(Int) -> atom() when Int :: integer().\n"
@@ -3137,6 +3142,13 @@ spec(Config) when is_list(Config) ->
         "    Int :: integer().\n",
         40
     ),
+    % ?assertFormat(
+    %     "-spec foo(Int) ->\n"
+    %     "    atom() when\n"
+    %     "    Int :: integer().\n",
+    %     "-spec foo(Int) -> atom() when\n"
+    %     "    Int :: integer().\n"
+    % ),
     ?assertFormat(
         "-spec foo(Int) -> some_very:very(long, type) when Int :: integer().",
         "-spec foo(Int) ->\n"
@@ -3165,7 +3177,8 @@ spec(Config) when is_list(Config) ->
         "-spec foo\n"
         "    (integer()) ->\n"
         "        some_very:very(long, type);\n"
-        "    (1..2) -> atom().\n",
+        "    (1..2) ->\n"
+        "        atom().\n",
         40
     ),
     ?assertFormat(
@@ -3175,7 +3188,8 @@ spec(Config) when is_list(Config) ->
         "        some_very_very:very(long, type)\n"
         "    when\n"
         "        Int :: integer();\n"
-        "    (1..2) -> atom().\n",
+        "    (1..2) ->\n"
+        "        atom().\n",
         40
     ),
     ?assertFormat(
@@ -3208,10 +3222,8 @@ spec(Config) when is_list(Config) ->
     ),
     ?assertFormat(
         "-spec foo(very_long_type(), another_long_type()) -> some_very:very(long, type).",
-        "-spec foo(\n"
-        "    very_long_type(),\n"
-        "    another_long_type()\n"
-        ") -> some_very:very(long, type).\n",
+        "-spec foo(very_long_type(), another_long_type()) ->\n"
+        "    some_very:very(long, type).\n",
         50
     ),
     ?assertFormat(
@@ -3221,7 +3233,8 @@ spec(Config) when is_list(Config) ->
         "    | #blonglonglong{}\n"
         "    | #c{}\n"
         "    | #d{}\n"
-        ") -> binary().\n",
+        ") ->\n"
+        "    binary().\n",
         30
     ),
     ?assertSame(
@@ -3231,7 +3244,8 @@ spec(Config) when is_list(Config) ->
         "    binary() | null,\n"
         "    credit | {refund | dispute, binary()},\n"
         "    binary() | null\n"
-        ") -> ok.\n"
+        ") ->\n"
+        "    ok.\n"
     ),
     ?assertSame(
         "-spec my_fun(TypeA, TypeB) -> ok when\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -3146,6 +3146,22 @@ spec(Config) when is_list(Config) ->
         "-spec foo(Int) ->\n"
         "    atom() when\n"
         "    Int :: integer().\n",
+        "-spec foo(Int) ->\n"
+        "    atom()\n"
+        "when\n"
+        "    Int :: integer().\n"
+    ),
+    ?assertFormat(
+        "-spec foo(Int) ->\n"
+        "    atom() when Int :: integer().\n",
+        "-spec foo(Int) ->\n"
+        "    atom()\n"
+        "when\n"
+        "    Int :: integer().\n"
+    ),
+    ?assertFormat(
+        "-spec foo(Int) -> atom() when\n"
+        "    Int :: integer().\n",
         "-spec foo(Int) -> atom() when Int :: integer().\n"
     ),
     ?assertFormat(

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -3162,7 +3162,20 @@ spec(Config) when is_list(Config) ->
     ?assertFormat(
         "-spec foo(Int) -> atom() when\n"
         "    Int :: integer().\n",
-        "-spec foo(Int) -> atom() when Int :: integer().\n"
+        "-spec foo(Int) -> atom() when\n"
+        "    Int :: integer().\n"
+    ),
+    ?assertSame(
+        "bar(X) when is_list(X) ->\n"
+        "    ok.\n"
+    ),
+    ?assertFormat(
+        "bar(X) when\n"
+        "   is_list(X) -> ok.\n",
+        "bar(X) when\n"
+        "    is_list(X)\n"
+        "->\n"
+        "    ok.\n"
     ),
     ?assertFormat(
         "-spec foo(Int) -> some_very:very(long, type) when Int :: integer().",
@@ -3324,7 +3337,8 @@ spec(Config) when is_list(Config) ->
         "    Int :: integer()\n"
         "    %% after clause comment\n"
         "    .\n",
-        "-spec foo(Int) -> atom() when Int :: integer()\n"
+        "-spec foo(Int) -> atom() when\n"
+        "    Int :: integer()\n"
         "%% after clause comment\n"
         ".\n"
     ),

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -3142,13 +3142,12 @@ spec(Config) when is_list(Config) ->
         "    Int :: integer().\n",
         40
     ),
-    % ?assertFormat(
-    %     "-spec foo(Int) ->\n"
-    %     "    atom() when\n"
-    %     "    Int :: integer().\n",
-    %     "-spec foo(Int) -> atom() when\n"
-    %     "    Int :: integer().\n"
-    % ),
+    ?assertFormat(
+        "-spec foo(Int) ->\n"
+        "    atom() when\n"
+        "    Int :: integer().\n",
+        "-spec foo(Int) -> atom() when Int :: integer().\n"
+    ),
     ?assertFormat(
         "-spec foo(Int) -> some_very:very(long, type) when Int :: integer().",
         "-spec foo(Int) ->\n"


### PR DESCRIPTION
Possibly fixes https://github.com/WhatsApp/erlfmt/issues/272

This makes the following a mirror of each other:
`clause_to_algebra({clause, _Meta, Head, empty, Body}) ->`
`clause_to_algebra({spec_clause, _Meta, Head, Body, empty}) ->`

This means we remove a `group` around `nest`, which when the spec parameters breaks the space after `->` return also breaks.

An alternative would be to keep the group, but add 
`MaybeForce = maybe_force_break(has_break_between(Head, Body))`
`group(nest(concat([MaybeForce, <<"->">>, break(<<" ">>), BodyD]), ?INDENT))`
But then maybe we should do the same for the other two `clause_to_algebra`s for consistency?