### PR TITLE
Fix end_location in raw_string anno

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -317,8 +317,8 @@ contains_ignore_comment({comment, _Loc, Comments}) ->
     ).
 
 node_string(Cont) ->
-    {String, Anno} = erlfmt_scan:last_node_string(Cont),
-    {raw_string, Anno, string:trim(String, both, "\n")}.
+    {String, Anno} = erlfmt_scan:last_node_string_trimmed(Cont),
+    {raw_string, Anno, String}.
 
 -spec format_nodes([erlfmt_parse:abstract_form()], pos_integer()) -> [unicode:chardata()].
 format_nodes([], _PrintWidth) ->
@@ -467,8 +467,8 @@ nodes_in_range(Nodes, StartLocation, EndLocation) ->
 
 node_intersects_range(Node, StartLocation, EndLocation) ->
     {Start, End} = get_location_range(Node),
-    ((Start < StartLocation) and (End >= StartLocation)) or
-        ((Start >= StartLocation) and (Start =< EndLocation)).
+    ((Start < StartLocation) and (End > StartLocation)) or
+        ((Start >= StartLocation) and (Start < EndLocation)).
 
 get_possible_locations([Option1, Option2 | _], Location, GetLoc) ->
     case GetLoc(Option1) of

--- a/src/erlfmt_scan.erl
+++ b/src/erlfmt_scan.erl
@@ -15,7 +15,14 @@
 
 -include("erlfmt_scan.hrl").
 
--export([io_node/1, string_node/1, continue/1, last_node_string/1]).
+-export([
+    io_node/1,
+    string_node/1,
+    continue/1,
+    last_node_string/1,
+    last_node_string_trimmed/1
+]).
+
 -export([
     put_anno/3,
     merge_anno/2,
@@ -180,6 +187,13 @@ last_node_string(#state{original = [First | _] = Tokens}) ->
     Location = erl_scan:location(First),
     {String, token_anno([{text, String}, {location, Location}])}.
 
+-spec last_node_string_trimmed(state()) -> {unicode:chardata(), anno()}.
+last_node_string_trimmed(#state{original = [First | _] = Tokens}) ->
+    String0 = stringify_tokens(Tokens),
+    String = string:trim(String0, both, "\n"),
+    Location = erl_scan:location(First),
+    {String, token_anno([{text, String}, {location, Location}])}.
+
 has_new_line({white_space, _, [$\n | _]}) -> true;
 has_new_line(_) -> false.
 
@@ -211,8 +225,9 @@ drop_initial_white_space([{white_space, _, _} | Rest]) ->
 drop_initial_white_space(Rest) ->
     Rest.
 
+-spec stringify_tokens([erl_scan:token()]) -> string().
 stringify_tokens(Tokens) ->
-    lists:map(fun erl_scan:text/1, Tokens).
+    lists:flatmap(fun erl_scan:text/1, Tokens).
 
 -spec split_tokens([erl_scan:token()], [erl_scan:token()]) ->
     {[token()], [erl_scan:token()], [comment()], [token()]}.


### PR DESCRIPTION
I noticed that for unparseable forms erlfmt parser returns incorrect end_location. The end_location is not used by erlfmt itself, but it can be useful for other tools. I'm unsure where a new testcase would fit as this internal thing does not affect formatting at all.

An example: (end column is the number of tokens (8) instead of the correct value 26)
```
1> {ok, Forms, _Warnings} = erlfmt:read_nodes_string("nofile", "f() -> \"very long string\""), Forms.
[{raw_string,#{end_location => {1,8},location => {1,1}},
             "f() -> \"very long string\""}]
2> length("f() -> \"very long string\"").
25
```