### PR TITLE
preserve spec alternative

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -712,7 +712,8 @@ clause_to_algebra({clause, _Meta, Head, empty, Body}) ->
 clause_to_algebra({spec_clause, _Meta, Head, Body, empty}) ->
     HeadD = clause_head_to_algebra(Head),
     BodyD = expr_to_algebra(Body),
-    space(HeadD, nest(break(<<"->">>, BodyD), ?INDENT));
+    MaybeForce = maybe_force_breaks(has_break_between(Head, Body)),
+    space(HeadD, group(nest(concat([MaybeForce, <<"->">>, break(<<" ">>), BodyD]), ?INDENT)));
 clause_to_algebra({clause, _Meta, empty, Guards, Body}) ->
     GuardsD = expr_to_algebra(Guards),
     BodyD = block_to_algebra(Body),

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -3130,8 +3130,7 @@ spec(Config) when is_list(Config) ->
         "        | {global, GlobalName :: any()}\n"
         "        | {via, Module :: atom(), ViaName :: any()},\n"
         "    another_field => atom()\n"
-        "}) ->\n"
-        "    supervisor:child_spec().\n"
+        "}) -> supervisor:child_spec().\n"
     ),
     ?assertSame(
         "-spec foo(Int) -> atom() when Int :: integer().\n"
@@ -3205,8 +3204,7 @@ spec(Config) when is_list(Config) ->
         "-spec foo\n"
         "    (integer()) ->\n"
         "        some_very:very(long, type);\n"
-        "    (1..2) ->\n"
-        "        atom().\n",
+        "    (1..2) -> atom().\n",
         40
     ),
     ?assertFormat(
@@ -3216,8 +3214,7 @@ spec(Config) when is_list(Config) ->
         "        some_very_very:very(long, type)\n"
         "    when\n"
         "        Int :: integer();\n"
-        "    (1..2) ->\n"
-        "        atom().\n",
+        "    (1..2) -> atom().\n",
         40
     ),
     ?assertFormat(
@@ -3261,9 +3258,17 @@ spec(Config) when is_list(Config) ->
         "    | #blonglonglong{}\n"
         "    | #c{}\n"
         "    | #d{}\n"
-        ") ->\n"
-        "    binary().\n",
+        ") -> binary().\n",
         30
+    ),
+    ?assertSame(
+        "-spec use_credit(\n"
+        "    store:id(),\n"
+        "    decimal:decimal(),\n"
+        "    binary() | null,\n"
+        "    credit | {refund | dispute, binary()},\n"
+        "    binary() | null\n"
+        ") -> ok.\n"
     ),
     ?assertSame(
         "-spec use_credit(\n"


### PR DESCRIPTION
I decided to make `clause_to_algebra` a special case for `spec_clause` using `maybe_force_breaks`
The reason to try this alternative is to avoid cases such as:
```
-spec use_credit(
    store:id(),
    decimal:decimal(),
    binary() | null,
    credit | {refund | dispute, binary()},
    binary() | null
) ->
    ok.
use_credit(...
```
which is really popular in the whatsapp code base.

This version preserves the newline after spec, but does not force it when the function parameters for the spec breaks.

The reason I made spec_clause a special case is that for other clause types there is a conflict with the break behaviour in clauses https://github.com/whatsapp/erlfmt#in-clauses where breaking the first one should result in breaking all clauses.  