### PR TITLE
comment the @format pragma to avoid edoc warnings

### DIFF
--- a/doc/ErlangFormatterComparison.md
+++ b/doc/ErlangFormatterComparison.md
@@ -325,7 +325,7 @@ x() -> Foo = [short, list].
 `rebar3-format` allows you to opt out per file by adding `-format ignore.` to the top of your file.
 
 `erlfmt` allows you to opt-in per file and opt-out per top-level expression.
-Adding a comment to the top of the file `%% % @format` and running `erlfmt` with the `--require-pragma` option, will result in only files that have this comment will be formatted.
+Adding a comment to the top of the file `%%% % @format` and running `erlfmt` with the `--require-pragma` option, will result in only files that have this comment will be formatted.
 
 Adding a comment `%% erlfmt-ignore` above a top level expression, will skip over this single expression and continue to format the rest of the file.
 [Here](https://github.com/WhatsApp/erlfmt/blob/master/doc/FormattingDecisionIgnore.md) you can see the reasoning behind including this option.

--- a/doc/ErlangFormatterComparison.md
+++ b/doc/ErlangFormatterComparison.md
@@ -325,7 +325,7 @@ x() -> Foo = [short, list].
 `rebar3-format` allows you to opt out per file by adding `-format ignore.` to the top of your file.
 
 `erlfmt` allows you to opt-in per file and opt-out per top-level expression.
-Adding a comment to the top of the file `%% @format` and running `erlfmt` with the `--require-pragma` option, will result in only files that have this comment will be formatted.
+Adding a comment to the top of the file `%% % @format` and running `erlfmt` with the `--require-pragma` option, will result in only files that have this comment will be formatted.
 
 Adding a comment `%% erlfmt-ignore` above a top level expression, will skip over this single expression and continue to format the rest of the file.
 [Here](https://github.com/WhatsApp/erlfmt/blob/master/doc/FormattingDecisionIgnore.md) you can see the reasoning behind including this option.
@@ -346,4 +346,3 @@ Executed in    6.86 secs   fish           external
 $ cat otp/lib/*/{src,include}/*.{e,h}rl | wc -l
 1361202 (1.36M)
 ```
-

--- a/doc/RebarUsage.md
+++ b/doc/RebarUsage.md
@@ -41,7 +41,7 @@ $ rebar3 fmt ./src/myfile.erl
 ```
 
 You could also setup your rebar3 config to:
-  - only format files that include a `%% % @format` comment, using `require_pragma`,
+  - only format files that include a `%%% % @format` comment, using `require_pragma`,
   - only check files and not format them, using `check` instead of `write`,
   - output which files are being checked, using `verbose` and
   - set the default width, using `{print_width, 100}`

--- a/doc/RebarUsage.md
+++ b/doc/RebarUsage.md
@@ -41,7 +41,7 @@ $ rebar3 fmt ./src/myfile.erl
 ```
 
 You could also setup your rebar3 config to:
-  - only format files that include a `%% @format` comment, using `require_pragma`,
+  - only format files that include a `%% % @format` comment, using `require_pragma`,
   - only check files and not format them, using `check` instead of `write`,
   - output which files are being checked, using `verbose` and
   - set the default width, using `{print_width, 100}`
@@ -65,4 +65,3 @@ $ rebar3 --help
 ```
 Simply convert dashes to underscores as appropriate,
 for example `--insert-pragma`, becomes `insert_pragma`.
-

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -200,7 +200,8 @@ replace_pragma_comment_blocks(_Prefix, []) ->
     [];
 replace_pragma_comment_blocks(Prefix, [{comment, Loc, Comments} | Rest]) ->
     case replace_pragma_comment_block(Prefix, Comments) of
-        [] -> replace_pragma_comment_block(Prefix, Rest);
+        [] ->
+            replace_pragma_comment_block(Prefix, Rest);
         CleanComments ->
             {Prefix0, _} = string:take(lists:last(CleanComments), "%"),
             [{comment, Loc, CleanComments} | replace_pragma_comment_block(Prefix0, Rest)]

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -199,13 +199,9 @@ replace_pragma_node(Node0) ->
 replace_pragma_comment_blocks(_Prefix, []) ->
     [];
 replace_pragma_comment_blocks(Prefix, [{comment, Loc, Comments} | Rest]) ->
-    case replace_pragma_comment_block(Prefix, Comments) of
-        [] ->
-            replace_pragma_comment_block(Prefix, Rest);
-        CleanComments ->
-            {Prefix0, _} = string:take(lists:last(CleanComments), "%"),
-            [{comment, Loc, CleanComments} | replace_pragma_comment_block(Prefix0, Rest)]
-    end.
+    CleanComments = replace_pragma_comment_block(Prefix, Comments),
+    {Prefix0, _} = string:take(lists:last(CleanComments), "%"),
+    [{comment, Loc, CleanComments} | replace_pragma_comment_block(Prefix0, Rest)].
 
 replace_pragma_comment_block(_Prefix, []) ->
     [];

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -129,12 +129,12 @@ insert_pragma_nodes([]) ->
     [];
 insert_pragma_nodes([{shebang, _, _} = Node | Nodes]) ->
     case contains_pragma_node(Node) of
-        true -> [Node | Nodes];
+        true -> [replace_pragma_node(Node) | Nodes];
         false -> [Node | insert_pragma_nodes(Nodes)]
     end;
 insert_pragma_nodes([Node | Nodes]) ->
     case contains_pragma_node(Node) of
-        true -> [Node | Nodes];
+        true -> [replace_pragma_node(Node) | Nodes];
         false -> [insert_pragma_node(Node) | Nodes]
     end.
 
@@ -144,11 +144,11 @@ insert_pragma_node(Node) ->
         case PreComments of
             [] ->
                 Loc = erlfmt_scan:get_anno(location, Node),
-                [{comment, #{location => Loc, end_location => Loc}, ["%% @format", ""]}];
+                [{comment, #{location => Loc, end_location => Loc}, ["%% % @format", ""]}];
             _ ->
                 {comment, Loc, LastComments} = lists:last(PreComments),
                 lists:droplast(PreComments) ++
-                    [{comment, Loc, LastComments ++ ["%% @format"]}]
+                    [{comment, Loc, LastComments ++ ["%% % @format"]}]
         end,
     erlfmt_scan:put_anno(pre_comments, NewPreComments, Node).
 
@@ -187,6 +187,28 @@ remove_pragma_comment_block([Head | Tail]) ->
         nomatch -> [Head | remove_pragma_comment_block(Tail)];
         _ -> Tail
     end.
+
+replace_pragma_node(Node0) ->
+    {PreComments0, _, PostComments0} = erlfmt_format:comments_with_pre_dot(Node0),
+    PreComments = replace_pragma_comment_blocks(PreComments0),
+    PostComments = replace_pragma_comment_blocks(PostComments0),
+    Node = erlfmt_scan:put_anno(pre_comments, PreComments, Node0),
+    erlfmt_scan:put_anno(post_comments, PostComments, Node).
+
+replace_pragma_comment_blocks([]) ->
+    [];
+replace_pragma_comment_blocks([{comment, Loc, Comments} | Rest]) ->
+    case replace_pragma_comment_block(Comments) of
+        [] -> replace_pragma_comment_block(Rest);
+        CleanComments -> [{comment, Loc, CleanComments} | replace_pragma_comment_block(Rest)]
+    end.
+
+replace_pragma_comment_block([]) ->
+    [];
+replace_pragma_comment_block(["%% @format" | Tail]) ->
+    ["%% % @format" | Tail];
+replace_pragma_comment_block([Head | Tail]) ->
+    [Head | replace_pragma_comment_block(Tail)].
 
 -spec format_range(
     file:name_all(),

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -144,11 +144,11 @@ insert_pragma_node(Node) ->
         case PreComments of
             [] ->
                 Loc = erlfmt_scan:get_anno(location, Node),
-                [{comment, #{location => Loc, end_location => Loc}, ["%% % @format", ""]}];
+                [{comment, #{location => Loc, end_location => Loc}, ["%%% % @format", ""]}];
             _ ->
                 {comment, Loc, LastComments} = lists:last(PreComments),
                 lists:droplast(PreComments) ++
-                    [{comment, Loc, LastComments ++ ["%% % @format"]}]
+                    [{comment, Loc, LastComments ++ ["%%% % @format"]}]
         end,
     erlfmt_scan:put_anno(pre_comments, NewPreComments, Node).
 
@@ -206,7 +206,7 @@ replace_pragma_comment_blocks([{comment, Loc, Comments} | Rest]) ->
 replace_pragma_comment_block([]) ->
     [];
 replace_pragma_comment_block(["%% @format" | Tail]) ->
-    ["%% % @format" | Tail];
+    ["%%% % @format" | Tail];
 replace_pragma_comment_block([Head | Tail]) ->
     [Head | replace_pragma_comment_block(Tail)].
 

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1060,6 +1060,7 @@ smoke_test_stdio_reinsert_pragma(Config) when is_list(Config) ->
         "-module(nopragma).\n",
     ?assertEqual(Expected, Formatted).
 
+%% respect the number of percentages when replacing the pragma
 smoke_test_stdio_reinsert_pragma_second(Config) when is_list(Config) ->
     Formatted = os:cmd(
         "echo '%% copyright\n%% @format\n\n-module(nopragma).' | " ++ escript() ++

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1016,7 +1016,7 @@ smoke_test_stdio_unicode(Config) ->
 smoke_test_stdio_insert_pragma_without(Config) when is_list(Config) ->
     Formatted = os:cmd("echo '-module(nopragma).' | " ++ escript() ++ " - --insert-pragma"),
     Expected =
-        "%% % @format\n"
+        "%%% % @format\n"
         "\n"
         "-module(nopragma).\n",
     ?assertEqual(Expected, Formatted).
@@ -1048,12 +1048,12 @@ smoke_test_stdio_delete_pragma_with_copyright(Config) when is_list(Config) ->
 
 smoke_test_stdio_reinsert_pragma(Config) when is_list(Config) ->
     Formatted = os:cmd(
-        "echo '%% @format\n%% copyright\n\n-module(nopragma).' | " ++ escript() ++
+        "echo '%% @format\n%%% copyright\n\n-module(nopragma).' | " ++ escript() ++
             " - --insert-pragma"
     ),
     Expected =
-        "%% % @format\n"
-        "%% copyright\n"
+        "%%% % @format\n"
+        "%%% copyright\n"
         "\n"
         "-module(nopragma).\n",
     ?assertEqual(Expected, Formatted).
@@ -1312,7 +1312,7 @@ contains_pragma(Config) when is_list(Config) ->
 
 insert_pragma(Config) when is_list(Config) ->
     ?assertEqual(
-        "%% % @format\n"
+        "%%% % @format\n"
         "\n"
         "-module(pragma).\n",
         insert_pragma_string(
@@ -1320,7 +1320,7 @@ insert_pragma(Config) when is_list(Config) ->
         )
     ),
     ?assertEqual(
-        "%% % @format\n"
+        "%%% % @format\n"
         "\n"
         "-module(pragma).\n"
         "\n"
@@ -1338,48 +1338,27 @@ insert_pragma(Config) when is_list(Config) ->
         )
     ),
     ?assertEqual(
-        "%% attached comment\n"
-        "%% % @format\n"
+        "%%% attached comment\n"
+        "%%% % @format\n"
         "-module(pragma).\n"
         "\n"
         "-export([f/3]).\n",
         insert_pragma_string(
-            "%% attached comment\n"
+            "%%% attached comment\n"
             "-module(pragma).\n"
             "\n"
             "-export([f/3]).\n"
         )
     ),
     ?assertEqual(
-        "%% single comment\n"
-        "%% % @format\n"
+        "%%% single comment\n"
+        "%%% % @format\n"
         "\n"
         "-module(pragma).\n"
         "\n"
         "-export([f/3]).\n",
         insert_pragma_string(
-            "%% single comment\n"
-            "\n"
-            "-module(pragma).\n"
-            "\n"
-            "-export([f/3]).\n"
-        )
-    ),
-    ?assertEqual(
-        "%% LICENSE\n"
-        "%% LICENSE\n"
-        "%% LICENSE\n"
-        "%% LICENSE\n"
-        "%% % @format\n"
-        "\n"
-        "-module(pragma).\n"
-        "\n"
-        "-export([f/3]).\n",
-        insert_pragma_string(
-            "%% LICENSE\n"
-            "%% LICENSE\n"
-            "%% LICENSE\n"
-            "%% LICENSE\n"
+            "%%% single comment\n"
             "\n"
             "-module(pragma).\n"
             "\n"
@@ -1387,7 +1366,28 @@ insert_pragma(Config) when is_list(Config) ->
         )
     ),
     ?assertEqual(
-        "%% % @format\n"
+        "%%% LICENSE\n"
+        "%%% LICENSE\n"
+        "%%% LICENSE\n"
+        "%%% LICENSE\n"
+        "%%% % @format\n"
+        "\n"
+        "-module(pragma).\n"
+        "\n"
+        "-export([f/3]).\n",
+        insert_pragma_string(
+            "%%% LICENSE\n"
+            "%%% LICENSE\n"
+            "%%% LICENSE\n"
+            "%%% LICENSE\n"
+            "\n"
+            "-module(pragma).\n"
+            "\n"
+            "-export([f/3]).\n"
+        )
+    ),
+    ?assertEqual(
+        "%%% % @format\n"
         "\n"
         "{erl_opts, [debug_info]}\n",
         insert_pragma_string(
@@ -1397,7 +1397,7 @@ insert_pragma(Config) when is_list(Config) ->
     ?assertEqual(
         "#! /usr/bin/env escript\n"
         "\n"
-        "%% % @format\n"
+        "%%% % @format\n"
         "\n"
         "main(_) -> ok.\n",
         insert_pragma_string(

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -58,6 +58,7 @@
     smoke_test_stdio_delete_pragma/1,
     smoke_test_stdio_delete_pragma_without/1,
     smoke_test_stdio_delete_pragma_with_copyright/1,
+    smoke_test_stdio_reinsert_pragma/1,
     smoke_test_stdio_unicode/1,
     smoke_test_stdio_check/1,
     exclude_check/1,
@@ -144,6 +145,7 @@ groups() ->
             smoke_test_stdio_delete_pragma,
             smoke_test_stdio_delete_pragma_without,
             smoke_test_stdio_delete_pragma_with_copyright,
+            smoke_test_stdio_reinsert_pragma,
             smoke_test_stdio_unicode,
             smoke_test_stdio_check,
             exclude_check
@@ -1014,7 +1016,7 @@ smoke_test_stdio_unicode(Config) ->
 smoke_test_stdio_insert_pragma_without(Config) when is_list(Config) ->
     Formatted = os:cmd("echo '-module(nopragma).' | " ++ escript() ++ " - --insert-pragma"),
     Expected =
-        "%% @format\n"
+        "%% % @format\n"
         "\n"
         "-module(nopragma).\n",
     ?assertEqual(Expected, Formatted).
@@ -1039,6 +1041,18 @@ smoke_test_stdio_delete_pragma_with_copyright(Config) when is_list(Config) ->
             " - --delete-pragma"
     ),
     Expected =
+        "%% copyright\n"
+        "\n"
+        "-module(nopragma).\n",
+    ?assertEqual(Expected, Formatted).
+
+smoke_test_stdio_reinsert_pragma(Config) when is_list(Config) ->
+    Formatted = os:cmd(
+        "echo '%% @format\n%% copyright\n\n-module(nopragma).' | " ++ escript() ++
+            " - --insert-pragma"
+    ),
+    Expected =
+        "%% % @format\n"
         "%% copyright\n"
         "\n"
         "-module(nopragma).\n",
@@ -1189,6 +1203,18 @@ range_format_exact([{Start, End} | Options], Path) ->
 contains_pragma(Config) when is_list(Config) ->
     ?assert(
         contains_pragma_string(
+            "%% % @format\n"
+            "\n"
+            "-module(pragma).\n"
+            "\n"
+            "-export([f/3]).\n"
+            "\n"
+            "f(_Arg1,_Arg2,   _Arg3) ->\n"
+            "ok.\n"
+        )
+    ),
+    ?assert(
+        contains_pragma_string(
             "%% @format\n"
             "\n"
             "-module(pragma).\n"
@@ -1203,7 +1229,7 @@ contains_pragma(Config) when is_list(Config) ->
         contains_pragma_string(
             "\n"
             "\n"
-            "%% @format\n"
+            "%% % @format\n"
             "\n"
             "-module(pragma).\n"
         )
@@ -1239,7 +1265,7 @@ contains_pragma(Config) when is_list(Config) ->
             "%% LICENSE\n"
             "%% LICENSE\n"
             "\n"
-            "%% @format\n"
+            "%% % @format\n"
             "\n"
             "-module(pragma).\n"
             "\n"
@@ -1262,7 +1288,7 @@ contains_pragma(Config) when is_list(Config) ->
     ),
     ?assert(
         contains_pragma_string(
-            "%% @format\n"
+            "%% % @format\n"
             "\n"
             "{erl_opts, [debug_info]}\n"
         )
@@ -1271,7 +1297,7 @@ contains_pragma(Config) when is_list(Config) ->
         contains_pragma_string(
             "#! /usr/bin/env escript\n"
             "\n"
-            "%% @format\n"
+            "%% % @format\n"
             "\n"
             "main(_) -> ok.\n"
         )
@@ -1286,7 +1312,7 @@ contains_pragma(Config) when is_list(Config) ->
 
 insert_pragma(Config) when is_list(Config) ->
     ?assertEqual(
-        "%% @format\n"
+        "%% % @format\n"
         "\n"
         "-module(pragma).\n",
         insert_pragma_string(
@@ -1294,7 +1320,7 @@ insert_pragma(Config) when is_list(Config) ->
         )
     ),
     ?assertEqual(
-        "%% @format\n"
+        "%% % @format\n"
         "\n"
         "-module(pragma).\n"
         "\n"
@@ -1313,7 +1339,7 @@ insert_pragma(Config) when is_list(Config) ->
     ),
     ?assertEqual(
         "%% attached comment\n"
-        "%% @format\n"
+        "%% % @format\n"
         "-module(pragma).\n"
         "\n"
         "-export([f/3]).\n",
@@ -1326,7 +1352,7 @@ insert_pragma(Config) when is_list(Config) ->
     ),
     ?assertEqual(
         "%% single comment\n"
-        "%% @format\n"
+        "%% % @format\n"
         "\n"
         "-module(pragma).\n"
         "\n"
@@ -1344,7 +1370,7 @@ insert_pragma(Config) when is_list(Config) ->
         "%% LICENSE\n"
         "%% LICENSE\n"
         "%% LICENSE\n"
-        "%% @format\n"
+        "%% % @format\n"
         "\n"
         "-module(pragma).\n"
         "\n"
@@ -1361,7 +1387,7 @@ insert_pragma(Config) when is_list(Config) ->
         )
     ),
     ?assertEqual(
-        "%% @format\n"
+        "%% % @format\n"
         "\n"
         "{erl_opts, [debug_info]}\n",
         insert_pragma_string(
@@ -1371,7 +1397,7 @@ insert_pragma(Config) when is_list(Config) ->
     ?assertEqual(
         "#! /usr/bin/env escript\n"
         "\n"
-        "%% @format\n"
+        "%% % @format\n"
         "\n"
         "main(_) -> ok.\n",
         insert_pragma_string(

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -59,6 +59,7 @@
     smoke_test_stdio_delete_pragma_without/1,
     smoke_test_stdio_delete_pragma_with_copyright/1,
     smoke_test_stdio_reinsert_pragma/1,
+    smoke_test_stdio_reinsert_pragma_second/1,
     smoke_test_stdio_unicode/1,
     smoke_test_stdio_check/1,
     exclude_check/1,
@@ -146,6 +147,7 @@ groups() ->
             smoke_test_stdio_delete_pragma_without,
             smoke_test_stdio_delete_pragma_with_copyright,
             smoke_test_stdio_reinsert_pragma,
+            smoke_test_stdio_reinsert_pragma_second,
             smoke_test_stdio_unicode,
             smoke_test_stdio_check,
             exclude_check
@@ -1054,6 +1056,18 @@ smoke_test_stdio_reinsert_pragma(Config) when is_list(Config) ->
     Expected =
         "%%% % @format\n"
         "%%% copyright\n"
+        "\n"
+        "-module(nopragma).\n",
+    ?assertEqual(Expected, Formatted).
+
+smoke_test_stdio_reinsert_pragma_second(Config) when is_list(Config) ->
+    Formatted = os:cmd(
+        "echo '%% copyright\n%% @format\n\n-module(nopragma).' | " ++ escript() ++
+            " - --insert-pragma"
+    ),
+    Expected =
+        "%% copyright\n"
+        "%% % @format\n"
         "\n"
         "-module(nopragma).\n",
     ?assertEqual(Expected, Formatted).

--- a/test/erlfmt_SUITE_data/pragma.erl
+++ b/test/erlfmt_SUITE_data/pragma.erl
@@ -1,3 +1,3 @@
-%% @format
+%% % @format
 
 -module(pragma).


### PR DESCRIPTION
Fixes https://github.com/WhatsApp/erlfmt/issues/277

Some context: Marc-Andre has shown me an analyses of triple comments that removes the bias in my analyses, that shows that they are actually popular in erlang before the module attribute.  We will work on pushing this analyses to the repo, but I think we should adopt this style in insert pragma