### PR TITLE
Analysis: Number of percentages used for module documentation

### DIFF
--- a/doc/FormattingDecisionComments/module_comments.md
+++ b/doc/FormattingDecisionComments/module_comments.md
@@ -1,0 +1,44 @@
+# Analysis: Number of percentages on module documentation
+We have conducted a deeper analysis of the number of percentages used for module documentation. This is meant to guide our recommendation of the `%%% % @format` module pragma.
+
+From the empirical results below, it shows that while there is no explicit concensus, most projects prefer using `%%%` for module documentation, except for OTP which strongly favors `%%`.
+
+### Methodology
+We first isolated the comments located above the `-module` attribute and counted the number of blocks (as opposed to single lines)
+for each number of percentage, this avoids skewing the results towards lengthy multi-line comment blocks. We also removed all `%% @format` headings to give a better representation of usage.
+We have then outputed as a percentage of total blocks the number of percentages used by each repository.
+
+### Results
+
+```
+OTP
+%: 0.7%
+%%: 91.5%
+%%%: 7.8%
+
+ejabberd
+%: 0.0%
+%%: 16.9%
+%%%: 83.1%
+
+MongooseIM
+%: 0.2%
+%%: 40.1%
+%%%: 59.7%
+
+Inaka
+%: 8.3%
+%%: 23.4%
+%%%: 68.3%
+
+kazoo
+%: 0.0%
+%%: 0.0%
+%%%: 100.0%
+
+WhatsApp
+%: 17.4%
+%%: 15.6%
+%%%: 67.0%
+```
+Source: [./module_comments.sh](./module_comments.sh)

--- a/doc/FormattingDecisionComments/module_comments.sh
+++ b/doc/FormattingDecisionComments/module_comments.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare -A repos
+declare -A comments
+
+repos["OTP"]="../../../otp"
+repos["kazoo"]="../../../kazoo"
+repos["Inaka"]="../../../inaka"
+repos["MongooseIM"]="../../../MongooseIM"
+repos["ejabberd"]="../../../ejabberd"
+repos["WhatsApp"]="../../../whatsapp/server/erl"
+
+function sum() {
+    local -n array=$1
+    for i in ${array[@]}; do
+        let sum+=$i
+    done
+    echo $sum
+}
+
+function repeat() {
+    printf "%$1s" | tr " " $2
+}
+
+for repo in ${!repos[*]}; do
+    echo $repo
+
+    for num_percentage in {1..3}; do
+        comments[$num_percentage]=`eval "find ${repos[$repo]} -name '*.erl' -not -path '**SUITE_data/*' -not -name '*trpc_*' -not -name '*_pb.erl' -print0 \
+        | xargs -0 -I %1 -n1 sh -c 'echo %1; sed -n \"0,/-module/p\" %1 | pcre2grep -Mo \"^(?:%{$num_percentage}(?:\n|[^%\n][^\n]*\n))+\" \
+        | pcre2grep -Mv \"%% @format\n\n\"' | awk 'BEGIN {SUM = 0} !NF {SUM += 1} END { print SUM }'"`
+    done
+
+    repo_total=$(sum comments)
+
+    for num_percentage in {1..3}; do
+        printf "%s: %.1f%%\n" \
+            `repeat $num_percentage "%"` \
+            `eval "bc -l <<< \"${comments[$num_percentage]} * 100 / $repo_total\""`
+    done
+
+    printf '\n'
+done


### PR DESCRIPTION
I've added a deeper analysis of the number of percentages used for module documentation.

I hope this guides the project recommendation of `%%% @format`  as opposed to the proposed `%% @format` heading.

Any feedback welcomed