### PR TITLE
fix replace pragma for empty lines

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -207,8 +207,10 @@ replace_pragma_comment_block(_Prefix, []) ->
     [];
 replace_pragma_comment_block(Prefix, ["%% @format" | Tail]) ->
     [(Prefix ++ " % @format") | Tail];
-replace_pragma_comment_block(_Prefix, [Head | Tail]) ->
+replace_pragma_comment_block(_Prefix, [("%" ++ _) = Head | Tail]) ->
     {Prefix, _} = string:take(Head, "%"),
+    [Head | replace_pragma_comment_block(Prefix, Tail)];
+replace_pragma_comment_block(Prefix, [Head | Tail]) ->
     [Head | replace_pragma_comment_block(Prefix, Tail)].
 
 -spec format_range(

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -60,6 +60,7 @@
     smoke_test_stdio_delete_pragma_with_copyright/1,
     smoke_test_stdio_reinsert_pragma/1,
     smoke_test_stdio_reinsert_pragma_second/1,
+    smoke_test_stdio_reinsert_pragma_config/1,
     smoke_test_stdio_unicode/1,
     smoke_test_stdio_check/1,
     exclude_check/1,
@@ -148,6 +149,7 @@ groups() ->
             smoke_test_stdio_delete_pragma_with_copyright,
             smoke_test_stdio_reinsert_pragma,
             smoke_test_stdio_reinsert_pragma_second,
+            smoke_test_stdio_reinsert_pragma_config,
             smoke_test_stdio_unicode,
             smoke_test_stdio_check,
             exclude_check
@@ -1071,6 +1073,18 @@ smoke_test_stdio_reinsert_pragma_second(Config) when is_list(Config) ->
         "%% % @format\n"
         "\n"
         "-module(nopragma).\n",
+    ?assertEqual(Expected, Formatted).
+
+smoke_test_stdio_reinsert_pragma_config(Config) when is_list(Config) ->
+    Formatted = os:cmd(
+        "echo '%% @format\n\n%%% actual comment\n{}.\n' | " ++ escript() ++
+            " - --insert-pragma"
+    ),
+    Expected =
+        "%%% % @format\n"
+        "\n"
+        "%%% actual comment\n"
+        "{}.\n",
     ?assertEqual(Expected, Formatted).
 
 smoke_test_stdio_insert_and_require_pragma(Config) when is_list(Config) ->


### PR DESCRIPTION
Got the following error: `function_clause,[{string,take_l,\n ... `
in `replace_pragma_comment_block`
Seems `replace_pragma_comment_block` couldn't handle empty lines in the comment block.