### PR TITLE
[Format range] Introduce functions to format enclosing range.

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -13,8 +13,6 @@
 %% limitations under the License.
 -module(erlfmt).
 
--include_lib("stdlib/include/assert.hrl").
-
 %% API exports
 -export([
     main/1,
@@ -249,12 +247,14 @@ format_string_range(String, StartLocation, EndLocation, Options) ->
 format_enclosing_range(FileName, StartLocation, EndLocation, Options, Nodes, Warnings) ->
     case format_range(FileName, StartLocation, EndLocation, Options, Nodes, Warnings) of
         {options, PossibleRanges} ->
-            % Pick the largest range, so all intersected forms are coverd.
+            % Pick the largest range, so all intersected forms are covered.
             {Starts, Ends} = lists:unzip(PossibleRanges),
             Start = lists:min(Starts),
             End = lists:max(Ends),
             Res = format_range(FileName, Start, End, Options, Nodes, Warnings),
-            ?assertNotMatch({options, _}, Res),
+            % Poor man's assert (to avoid including assert.hrl)
+            % This time we must have the formatted result.
+            {ok, _, _} = Res,
             Res;
         X ->
             % Already ok or error: pass as is.

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -21,10 +21,8 @@
     init/1,
     format_file/2,
     format_file_range/4,
-    format_file_enclosing_range/4,
     format_string/2,
     format_string_range/4,
-    format_string_enclosing_range/4,
     format_nodes/2,
     read_nodes/1,
     read_nodes_string/2,
@@ -218,11 +216,11 @@ replace_pragma_comment_block(_Prefix, [("%" ++ _) = Head | Tail]) ->
 replace_pragma_comment_block(Prefix, [Head | Tail]) ->
     [Head | replace_pragma_comment_block(Prefix, Tail)].
 
-% This 'enclosing range' variants don't expect you to provide
-% the exact range of a top level form (as does format_file_range).
-% Instead, it will format the minimum number of top level forms
+% Format the minimum number of top-level forms
 % that cover the passed range.
--spec format_file_enclosing_range(
+% Rationale: top-level forms is the smallest
+%            granularity we support now.
+-spec format_file_range(
     file:name_all(),
     erlfmt_scan:location(),
     erlfmt_scan:location(),
@@ -230,11 +228,11 @@ replace_pragma_comment_block(Prefix, [Head | Tail]) ->
 ) ->
     {ok, string(), [error_info()]}
     | {error, error_info()}.
-format_file_enclosing_range(FileName, StartLocation, EndLocation, Options) ->
+format_file_range(FileName, StartLocation, EndLocation, Options) ->
     {ok, Nodes, Warnings} = file_read_nodes(FileName, ignore),
     format_enclosing_range(FileName, StartLocation, EndLocation, Options, Nodes, Warnings).
 
--spec format_string_enclosing_range(
+-spec format_string_range(
     string(),
     erlfmt_scan:location(),
     erlfmt_scan:location(),
@@ -242,7 +240,7 @@ format_file_enclosing_range(FileName, StartLocation, EndLocation, Options) ->
 ) ->
     {ok, string(), [error_info()]}
     | {error, error_info()}.
-format_string_enclosing_range(String, StartLocation, EndLocation, Options) ->
+format_string_range(String, StartLocation, EndLocation, Options) ->
     FileName = "nofile",
     Pragma = proplists:get_value(pragma, Options, ignore),
     {ok, Nodes, Warnings} = read_nodes_string(FileName, String, Pragma),
@@ -262,26 +260,6 @@ format_enclosing_range(FileName, StartLocation, EndLocation, Options, Nodes, War
             % Already ok or error: pass as is.
             X
     end.
-
-% This variant returns
--spec format_file_range(
-    file:name_all(),
-    erlfmt_scan:location(),
-    erlfmt_scan:location(),
-    [{print_width, pos_integer()}]
-) ->
-    {ok, string(), [error_info()]}
-    | {error, error_info()}
-    | {options, [{erlfmt_scan:location(), erlfmt_scan:location()}]}.
-format_file_range(FileName, StartLocation, EndLocation, Options) ->
-    {ok, Nodes, Warnings} = file_read_nodes(FileName, ignore),
-    format_range(FileName, StartLocation, EndLocation, Options, Nodes, Warnings).
-
-format_string_range(String, StartLocation, EndLocation, Options) ->
-    FileName = "nofile",
-    Pragma = proplists:get_value(pragma, Options, ignore),
-    {ok, Nodes, Warnings} = read_nodes_string(FileName, String, Pragma),
-    format_range(FileName, StartLocation, EndLocation, Options, Nodes, Warnings).
 
 format_range(FileName, StartLocation, EndLocation, Options, Nodes, Warnings) ->
     PrintWidth = proplists:get_value(print_width, Options, ?DEFAULT_WIDTH),

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1300,7 +1300,7 @@ snapshot_enclosing_range(_) ->
         "x() ->\n"
         "    0.",
     % Range is just the first char (mimic e.g. function renaming).
-    Output = erlfmt:format_string_enclosing_range(Original, {1, 1}, {1, 2}, []),
+    Output = erlfmt:format_string_range(Original, {1, 1}, {1, 2}, []),
     assert_snapshot_match(list_to_binary(Reference), Output).
 
 snapshot_enclosing_range2(_) ->
@@ -1313,7 +1313,7 @@ snapshot_enclosing_range2(_) ->
     Reference =
         "x() ->\n"
         "    0.",
-    Output = erlfmt:format_string_enclosing_range(Original, {2, 2}, {2, 3}, []),
+    Output = erlfmt:format_string_range(Original, {2, 2}, {2, 3}, []),
     assert_snapshot_match(list_to_binary(Reference), Output).
 
 snapshot_enclosing_range_no_leak(_) ->
@@ -1328,7 +1328,7 @@ snapshot_enclosing_range_no_leak(_) ->
         "    0.",
     % End point overshots line 3, but doesn't reach line 4:
     % Only x() must be formatted.
-    Output = erlfmt:format_string_enclosing_range(Original, {1, 1}, {3, 3}, []),
+    Output = erlfmt:format_string_range(Original, {1, 1}, {3, 3}, []),
     assert_snapshot_match(list_to_binary(Reference), Output).
 
 contains_pragma(Config) when is_list(Config) ->


### PR DESCRIPTION
[Format range] Introduce functions to format enclosing range.

Context: For now we cannot format more granularly than top level forms.
Existing internal functions expect the passed range to cover exactly entire forms.

In prospect of user-friendly CLI, we introduce formatting entry points
that cover all the top level forms intersecting with passed range.
