### PR TITLE
Return exit code 2 when option isn't recognized.

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -54,7 +54,8 @@ main(Argv) ->
             erlfmt_cli:do("erlfmt", [{files, ExtraFiles} | ArgOpts]);
         {error, Error} ->
             io:put_chars(standard_error, [getopt:format_error(Opts, Error), "\n\n"]),
-            getopt:usage(Opts, "erlfmt")
+            getopt:usage(Opts, "erlfmt"),
+            erlang:halt(2)
     end.
 
 %% rebar3 plugin entry point


### PR DESCRIPTION
Follow standard practice, so that client code can detect if there is an issue.
We already returned error code 2 in other cases of option parsing failure,
now everything is covered in a consistent manner.
