### PR TITLE
Introduce semi-expanded format for all containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,84 +240,67 @@ inspect the code manually to correct similar sub-par layouts.
 
 The formatter keeps the original decisions in two key places
 
-  * when choosing between a "collapsed" and an "expanded" layout for containers
+  * when choosing between a "collapsed", "semi-expanded", and an "expanded" layout for containers
   * when choosing between single-line and multi-line clauses.
 
 ### In containers
 
-For containers like lists, tuples, maps, records, etc,
-there are two possible layouts - "collapsed" where the entire collection
-is printed in a single line; and "expanded" where each element is printed on a
+For containers like lists, tuples, maps, records, function calls, etc,
+there are three possible layouts - "collapsed" where the entire collection
+is printed in a single line; "semi-expanded" where the enclosing
+brackets/breaces/parentheses are printed on a line of their own, but all elements
+are printed in a single line; and "expanded" where each element is printed on a
 separate line. The formatter respects this choice, if possible. If there is a
 newline between the opening bracket/brace/parenthesis and the first element,
-the collection will be always printed "expanded", for example:
+the collection will be always printed "semi-expanded", for example:
 
-```erlang formatted foobar
+```erlang formatted semi-expanded
+[
+    Foo, Bar
+]
+```
+
+will be preserved, even though it could fit on a single line.
+
+Similarly, if there's a break between any elements, the container will be printed
+in the "expanded" format:
+```erlang formatted expanded
 [
     Foo,
     Bar
 ]
 ```
 
-will be preserved, even though it could fit on a single line.
-This is controlled by whether the user has included a newline in the original version.
+This is controlled by the newlines in the original version.
 For example, merely deleting the newlines from the above sequence:
 
-```erlang unformatted foobar1
+```erlang unformatted collapsed
 [    Foo, Bar]
 ```
 
 and re-running the formatter, will produce:
 
-```erlang formatted foobar1
+```erlang formatted collapsed
 [Foo, Bar]
 ```
 
-Similarly, adding the single newline back:
+Similarly, adding the single initial newline back:
 
-```erlang unformatted foobar
+```erlang unformatted semi-expanded
 [
 Foo, Bar]
 ```
 
-and re-running the formatter, will produce the initial format again.
+and re-running the formatter, will produce the "semi-expanded" format again.
 
-### In functions
+While adding a newline in the middle:
 
-For function calls, function definitions, types, and macros, there are two possible
-layouts similar to lists, but also a third extra layout that puts all the arguments
-on the same line. This new format is preserved:
-
-```erlang formatted function
-function(
-    Argument1, Argument2, Argument3
-)
+```erlang unformatted expanded
+[Foo,
+Bar]
 ```
 
-Similar to the fully expanded format:
-
-```erlang formatted function-full
-function(
-    Argument1,
-    Argument2,
-    Argument3
-)
-```
-
-The expanded forms can be forced by including a newline between the parentheses
-and the first argument or in-between the arguments:
-```erlang unformatted function
-function(
-Argument1, Argument2, Argument3)
-```
-
-Will be formatted to the first snippet, while:
-```erlang unformatted function-full
-function(Argument1,
-Argument2, Argument3)
-```
-
-Will be formatted to the second snippet.
+and re-running the formatter, will produce the "expanded" format again.
 
 ### In clauses
 

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -415,7 +415,7 @@ with_next_break_fits(false, Doc, Fun) ->
     Fun(Doc).
 
 container(Meta, Values, Left, Right) ->
-    container_common(Meta, Values, Left, Right, break, last_normal).
+    container_common(Meta, Values, Left, Right, group_break, last_normal).
 
 flex_container(Meta, Values, Left, Right) ->
     container_common(Meta, Values, Left, Right, flex_break, last_fits).
@@ -461,12 +461,12 @@ break_behaviour(Meta, Values, BreakKind) ->
                 [SoleElement] ->
                     case is_container(SoleElement) of
                         true -> no_break;
-                        false -> break
+                        false -> group_break
                     end;
                 [First | _] ->
                     case is_tag(First) of
                         true -> BreakKind;
-                        false -> break
+                        false -> group_break
                     end;
                 _ ->
                     BreakKind
@@ -852,7 +852,7 @@ is_next_break_fits({FlexContainer, Meta, Values}) when
     FlexContainer =:= tuple; FlexContainer =:= bin
 ->
     BreakBehaviour = break_behaviour(Meta, Values, flex_break),
-    BreakBehaviour =:= break orelse BreakBehaviour =:= line;
+    BreakBehaviour =:= group_break orelse BreakBehaviour =:= line;
 is_next_break_fits(Expr) ->
     lists:member(element(1, Expr), [map, list, record, block, 'fun', lc, bc]) andalso
         has_no_comments_or_parens(Expr).

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -535,6 +535,8 @@ has_opening_line_break(Meta, [HeadValue | _]) ->
 
 has_any_break_between([Head | [Head2 | _] = Tail]) ->
     has_break_between(Head, Head2) orelse has_any_break_between(Tail);
+has_any_break_between([{cons, _, Head, Tail}]) ->
+    has_break_between(Head, Tail);
 has_any_break_between(_) ->
     false.
 

--- a/test/assert_diagnostic_SUITE.erl
+++ b/test/assert_diagnostic_SUITE.erl
@@ -17,8 +17,19 @@
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("test/assert_diagnostic.hrl").
 
-%% TestServer callbacks ++ test cases.
--compile(export_all).
+%% Test server callbacks
+-export([
+    all/0,
+    groups/0
+]).
+
+%% Test cases
+-export([
+    test_equal/1,
+    test_expected_is_longer/1,
+    test_actual_is_longer/1,
+    test_one_distinc_item/1
+]).
 
 groups() ->
     [
@@ -43,24 +54,24 @@ test_equal(_) ->
 test_expected_is_longer(_) ->
     L0 = [coffee, brownie],
     L1 = [coffee],
-    checkListEqualMessage(L0, L1, ["Actual list lacks 1 expected items: [brownie]"]).
+    check_list_equal_message(L0, L1, ["Actual list lacks 1 expected items: [brownie]"]).
 
 test_actual_is_longer(_) ->
     L0 = [breath],
     L1 = [breath, explode],
-    checkListEqualMessage(L0, L1, ["Actual list has 1 unexpected items: [explode]"]).
+    check_list_equal_message(L0, L1, ["Actual list has 1 unexpected items: [explode]"]).
 
 test_one_distinc_item(_) ->
     L0 = [sea, sax, sun],
     L1 = [sea, tex, sun],
-    checkListEqualMessage(L0, L1, [
+    check_list_equal_message(L0, L1, [
         "Item 2 differs:\n"
         "Expected: sax\n"
         "Value:    tex"
     ]).
 
 %% Helper ensuring comparison of mismatching lists give the expected message.
-checkListEqualMessage(L0, L1, Msg) ->
+check_list_equal_message(L0, L1, Msg) ->
     case (catch ?assertListEqual(L0, L1)) of
         ok ->
             ct:fail("Got 'ok', was expecting exception: ~p", [Msg]);

--- a/test/erlfmt_SUITE_data/comments.erl
+++ b/test/erlfmt_SUITE_data/comments.erl
@@ -5,6 +5,7 @@
 ]).
 
 -export([
+    foo/1,
     bar/1, baz/1
 ]).
 

--- a/test/erlfmt_SUITE_data/comments.erl.formatted
+++ b/test/erlfmt_SUITE_data/comments.erl.formatted
@@ -5,6 +5,7 @@
 ]).
 
 -export([
+    foo/1,
     bar/1,
     baz/1
 ]).

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1252,6 +1252,17 @@ untagged_tuple(Config) when is_list(Config) ->
         "], c}.\n",
         "{ajdsdjhasd, askjdasjkd,\n"
         "    [\n"
+        "        A, B\n"
+        "    ],\n"
+        "    c}.\n"
+    ),
+    ?assertFormat(
+        "{ajdsdjhasd, askjdasjkd, [\n"
+        "A,\n"
+        "B\n"
+        "], c}.\n",
+        "{ajdsdjhasd, askjdasjkd,\n"
+        "    [\n"
         "        A,\n"
         "        B\n"
         "    ],\n"
@@ -2152,9 +2163,7 @@ call(Config) when is_list(Config) ->
         "render(fold_doc(fun(D, Acc) -> concat([D,X,Acc]) end, [A,B,C]),80)",
         "render(\n"
         "    fold_doc(fun(D, Acc) -> concat([D, X, Acc]) end, [\n"
-        "        A,\n"
-        "        B,\n"
-        "        C\n"
+        "        A, B, C\n"
         "    ]),\n"
         "    80\n"
         ")\n",
@@ -3232,6 +3241,22 @@ exportimport(Config) when is_list(Config) ->
         "    c/1,\n"
         "    c/2\n"
         "]).\n"
+    ),
+    ?assertSame(
+        "-export([\n"
+        "    bar/1, baz/1\n"
+        "]).\n"
+    ),
+    ?assertFormat(
+        "-export([\n"
+        "    foo/1, bar/1,\n"
+        "    baz/1, baz/2\n"
+        "]).\n",
+        "-export([\n"
+        "    foo/1,\n"
+        "    bar/1,\n"
+        "    baz/1, baz/2\n"
+        "]).\n"
     ).
 
 ifdef(Config) when is_list(Config) ->
@@ -3296,12 +3321,19 @@ record_definition(Config) when is_list(Config) ->
     ?assertFormat(
         "-record(foo, {a = 1 :: integer(), b :: float(), c  = 2, d}).",
         "-record(foo, {\n"
+        "    a = 1 :: integer(), b :: float(), c = 2, d\n"
+        "}).\n",
+        50
+    ),
+    ?assertFormat(
+        "-record(foo, {a = 1 :: integer(), b :: float(), c  = 2, d}).",
+        "-record(foo, {\n"
         "    a = 1 :: integer(),\n"
         "    b :: float(),\n"
         "    c = 2,\n"
         "    d\n"
         "}).\n",
-        50
+        40
     ),
     ?assertSame(
         "-record(foo,\n"
@@ -3719,10 +3751,17 @@ type(Config) when is_list(Config) ->
     ?assertFormat(
         "-type foobar() :: #foo{a :: integer(), b :: mod:type()}.",
         "-type foobar() :: #foo{\n"
+        "    a :: integer(), b :: mod:type()\n"
+        "}.\n",
+        50
+    ),
+    ?assertFormat(
+        "-type foobar() :: #foo{a :: integer(), b :: mod:type()}.",
+        "-type foobar() :: #foo{\n"
         "    a :: integer(),\n"
         "    b :: mod:type()\n"
         "}.\n",
-        50
+        30
     ),
     ?assertSame(
         "-type foo() :: fun(\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1108,9 +1108,22 @@ tuple(Config) when is_list(Config) ->
         "    foo\n"
         "}\n"
     ),
-    ?assertFormat(
+    ?assertSame(
         "{\n"
         "    foo, bar, baz\n"
+        "}\n"
+    ),
+    ?assertSame(
+        "{\n"
+        "    foo,\n"
+        "    bar,\n"
+        "    baz\n"
+        "}\n"
+    ),
+    ?assertFormat(
+        "{\n"
+        "    foo, bar,\n"
+        "    baz\n"
         "}\n",
         "{\n"
         "    foo,\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -1518,6 +1518,12 @@ list(Config) when is_list(Config) ->
         "    3\n"
         "]\n"
     ),
+    ?assertSame(
+        "[\n"
+        "    1\n"
+        "    | 2\n"
+        "]\n"
+    ),
     ?assertFormat(
         "gen_part_decode_funcs({constructed,bif}, TypeName, {_Name,parts,Tag,_Type}) ->\n"
         "   emit([\n"


### PR DESCRIPTION
This change implements the semi-expanded format introduced for function calls in https://github.com/WhatsApp/erlfmt/pull/305 to all the containers.