### PR TITLE
Improve error_info() type

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -34,7 +34,9 @@
 
 -export_type([error_info/0, config/0, pragma/0]).
 
--type error_info() :: {file:name_all(), erl_anno:location(), module(), Reason :: any()}.
+-type error_info() :: {
+    file:name_all(), erl_anno:location() | erlfmt_scan:anno(), module(), Reason :: any()
+}.
 -type pragma() :: require | insert | delete | ignore.
 -type config() :: [{pragma, pragma()} | {print_width, pos_integer()} | verbose].
 

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -994,7 +994,7 @@ Erlang code.
 
 %% XXX. To be refined.
 -type error_description() :: term().
--type error_info() :: {erl_anno:line(), module(), error_description()}.
+-type error_info() :: {erl_anno:location() | erlfmt_scan:anno(), module(), error_description()}.
 -type token() :: erlfmt_scan:token().
 
 %% mkop(Op, Arg) -> {op,Anno,Op,Arg}.


### PR DESCRIPTION
`erlfmt_scan` returns `erl_anno:location()` in errors however `erlfmt_parse` mostly returns full `erlfmt_scan:anno()` maps. (I'm not sure if the parser should/can be changed to also return `location()` as the code generated by yecc just takes the second element of the token tuple, without any transformation, if it is not an `erl_anno:anno()` https://github.com/erlang/otp/blob/maint/lib/parsetools/include/yeccpre.hrl#L147) The errors from the parser also surface in the return value of `erlfmt:read_nodes[_string]`

I noticed this via dialyzer when calling `erlfmt_parse` directly.