### PR TITLE
stronger dialyzer checks

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,8 @@
 ]}.
 
 {dialyzer, [
-    {exclude_mods, [rebar3_fmt_prv]}
+    {exclude_mods, [rebar3_fmt_prv]},
+    {warnings, [unknown]}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
It turns out that when running dialyzer through rebar, - it would not by default report unknown types. `erlfmt` (after a series of refactorings such as `abstract_form()` -> `abstract_node()`) ended up in using not up-to-date types.

This PR is about opening a discussion for fixing types and specs in `erlfmt`. It cannot be landed yet AS IS in main, - since CI becomes red. I plan to fix types and specs properly in upcoming commits to this diff.