### PR TITLE
Read input only once

### DIFF
--- a/src/erlfmt_scan.erl
+++ b/src/erlfmt_scan.erl
@@ -16,7 +16,6 @@
 -include("erlfmt_scan.hrl").
 
 -export([
-    io_node/1,
     string_node/1,
     continue/1,
     last_node_string/1,
@@ -75,9 +74,6 @@
 
 -opaque state() :: #state{}.
 
--spec io_node(file:io_device()) -> node_ret().
-io_node(IO) -> node(fun io_scan_erl_node/2, IO).
-
 -spec string_node(string()) -> node_ret().
 string_node(String) -> node(fun erl_scan_tokens/2, String).
 
@@ -108,8 +104,6 @@ continue(Scan, Inner0, Loc0, []) ->
             continue(Scan, Inner, Loc, Tokens);
         {{error, Reason}, _Inner} ->
             {error, {Loc0, file, Reason}};
-        {eof, _Inner} ->
-            {eof, Loc0};
         {Other, _Inner} ->
             Other
     end;
@@ -165,9 +159,6 @@ read_rest(IO, Data) ->
         eof -> Data;
         {error, Reason} -> throw({error, Reason})
     end.
-
-io_scan_erl_node(IO, Loc) ->
-    {io:scan_erl_form(IO, "", Loc, ?ERL_SCAN_OPTS), IO}.
 
 erl_scan_tokens(String, Loc) ->
     case erl_scan:tokens([], String, Loc, ?ERL_SCAN_OPTS) of

--- a/test/assert_diagnostic.erl
+++ b/test/assert_diagnostic.erl
@@ -73,7 +73,7 @@ check_elements([H1 | T1], [H2 | T2], I) ->
 %% Check the formatted result matches the reference.
 assert_snapshot_match(Expected, Output) ->
     case Output of
-        {ok, Formatted, _} ->
+        {ok, _, Formatted, _} ->
             assert_binary_match(Expected, Formatted);
         {skip, _} ->
             ok;

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -1097,14 +1097,14 @@ format_range(Config, File) ->
     DataDir = ?config(data_dir, Config),
     Path = DataDir ++ File,
     case erlfmt:format_file_range(Path, {3, 45}, {47, 1}, []) of
-        {ok, _Output, _} -> ok;
+        {ok, _, _Output, _} -> ok;
         {options, Options} -> range_format_exact(Options, Path)
     end.
 
 range_format_exact([], _Path) ->
     ok;
 range_format_exact([{Start, End} | Options], Path) ->
-    {ok, _Output, _} = erlfmt:format_file_range(Path, Start, End, []),
+    {ok, _, _Output, _} = erlfmt:format_file_range(Path, Start, End, []),
     range_format_exact(Options, Path).
 
 snapshot_range_whole_comments(Config) ->
@@ -1530,11 +1530,11 @@ contains_pragma_string(String) ->
     end.
 
 insert_pragma_string(String) ->
-    {ok, StringWithPragma, []} = erlfmt:format_string(String, [{pragma, insert}]),
+    {ok, _, StringWithPragma, []} = erlfmt:format_string(String, [{pragma, insert}]),
     %% check that insert_pragma_nodes doesn't insert a pragma, when one has already been inserted.
     ?assertEqual(
         erlfmt:format_string(StringWithPragma, [{pragma, insert}]),
-        {ok, StringWithPragma, []}
+        {ok, StringWithPragma, StringWithPragma, []}
     ),
     StringWithPragma.
 
@@ -1542,10 +1542,10 @@ overlong_warning(Config) when is_list(Config) ->
     DataDir = ?config(data_dir, Config),
     FileName = filename:join([DataDir, "overlong.erl"]),
     Options = [verbose],
-    {ok, Formatted, FileWarnings} = erlfmt:format_file(FileName, Options),
+    {ok, _, Formatted, FileWarnings} = erlfmt:format_file(FileName, Options),
     FormattedList = unicode:characters_to_list(Formatted),
-    {ok, _, StringWarnings} = erlfmt:format_string(FormattedList, Options),
-    {ok, _, RangeWarnings} = erlfmt:format_file_range(
+    {ok, _, _, StringWarnings} = erlfmt:format_string(FormattedList, Options),
+    {ok, _, _, RangeWarnings} = erlfmt:format_file_range(
         FileName,
         {1, 1},
         {11, 8},

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -171,7 +171,7 @@ all() ->
 end).
 
 format_string(String, Options) ->
-    {ok, Formatted, []} = erlfmt:format_string(String, Options),
+    {ok, _, Formatted, []} = erlfmt:format_string(String, Options),
     Formatted.
 
 literals(Config) when is_list(Config) ->

--- a/test/erlfmt_markdown_SUITE.erl
+++ b/test/erlfmt_markdown_SUITE.erl
@@ -153,5 +153,5 @@ strip_good_bad("%% Bad\n" ++ Rest) -> Rest;
 strip_good_bad(Rest) -> Rest.
 
 check_fmt(Unformatted, Expected) ->
-    {ok, Got, []} = erlfmt:format_string(Unformatted, []),
+    {ok, _, Got, []} = erlfmt:format_string(Unformatted, []),
     ?assertEqual(string:trim(Expected), string:trim(Got)).


### PR DESCRIPTION
Close #238 

### Time
`time for i in {1..5}; _build/release/bin/erlfmt -w 'otp/lib/*/{src,include}/*.{erl,hrl}'; done`

### Potential incompatibility
Changed return of `format_[file, file_range, string_full, string_range]` to include the original. Type of formatted string from `[unicode:chardata()]` to `string()`.

`{ok, [unicode:chardata()], [error_info()]} | {skip, string()} | {error, error_info()}.`

to

`{ok, string(), string(), [error_info()]} | {skip, string()} | {error, error_info()}.`

Possible alternative: Introduce new tag `unchanged`.