### PR TITLE
Allow macro as case clause.

### DIFF
--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -414,6 +414,8 @@ cr_clauses -> cr_clause ';' cr_clauses : ['$1' | '$3'].
 
 cr_clause -> expr clause_guard clause_body :
     {clause, ?range_anno('$1', '$3'), '$1', '$2', ?val('$3')}.
+cr_clause -> macro_call_expr :
+    '$1'.
 
 receive_expr -> 'receive' cr_clauses 'end' :
         Clauses = {clauses, ?range_anno('$1', '$3'), '$2'},

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -2696,6 +2696,13 @@ case_expression(Config) when is_list(Config) ->
         "            {reply, ok, State}\n"
         "    end.\n",
         100
+    ),
+    ?assertFormat(
+        "case 1 of ?macro(1); ?macro(2) end",
+        "case 1 of\n"
+        "    ?macro(1);\n"
+        "    ?macro(2)\n"
+        "end\n"
     ).
 
 receive_expression(Config) when is_list(Config) ->


### PR DESCRIPTION
If you run erlfmt on a file like this:

```
-module(testar).

-define(tjo(A), A -> ok).

apa(B) ->
      case B of
   ?tjo(1)
   ;
          ?tjo(2)
	end.
```

Then you will get this error
testar.erl:8:4: syntax error before: ';'
and the apa function will not be formatted. (There is another error also for the define, but that is not solved by the current PR)

The parse error is due to the parser not allowing a macro as the whole case clause and thus gets a parse error when getting to the semi-colon. This kind of macro usage is found in the code base I work with. With this PR, the apa function can be parsed and is successfully formatted.