### PR TITLE
Implement `maybe_expr` support

### DIFF
--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -222,6 +222,16 @@ insert_nested({'case', Meta, Expr0, Clauses0}, Comments0) ->
     {Expr, Comments1} = insert_expr(Expr0, Comments0),
     Clauses = insert_expr_container(Clauses0, Comments1),
     {{'case', Meta, Expr, Clauses}, []};
+insert_nested({'maybe', Meta, MaybeExpressions0}, Comments0) ->
+    MaybeExpressions = insert_expr_container(MaybeExpressions0, Comments0),
+    {{'maybe', Meta, MaybeExpressions}, []};
+insert_nested({'maybe', Meta, MaybeExpressions0, ElseClause0}, Comments0) ->
+    {MaybeExpressions, Comments1} = insert_expr_list(MaybeExpressions0, Comments0),
+    {ElseClause, []} = insert_nested(ElseClause0, Comments1),
+    {{'maybe', Meta, MaybeExpressions, ElseClause}, []};
+insert_nested({'else_clause', Meta, Clauses0}, Comments0) ->
+    Clauses = insert_expr_container(Clauses0, Comments0),
+    {{'else_clause', Meta, Clauses}, []};
 insert_nested({'receive', Meta, Clauses0}, Comments0) ->
     {Clauses, []} = insert_expr(Clauses0, Comments0),
     {{'receive', Meta, Clauses}, []};

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -274,11 +274,11 @@ attributes(Config) when is_list(Config) ->
         parse_form("-if(?foo == 2).")
     ),
     ?assertMatch(
-        {attribute, _, {atom, _, else}, no_parens},
+        {attribute, _, {atom, _, 'else'}, no_parens},
         parse_form("-else.")
     ),
     ?assertMatch(
-        {attribute, _, {atom, _, else}, []},
+        {attribute, _, {atom, _, 'else'}, []},
         parse_form("-else().")
     ),
     ?assertMatch(

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -52,6 +52,7 @@
     block/1,
     fun_expression/1,
     case_expression/1,
+    maybe_expression/1,
     receive_expression/1,
     try_expression/1,
     if_expression/1,
@@ -106,6 +107,7 @@ groups() ->
             block,
             fun_expression,
             case_expression,
+            maybe_expression,
             receive_expression,
             try_expression,
             if_expression,
@@ -2704,6 +2706,54 @@ case_expression(Config) when is_list(Config) ->
         "    ?macro(2)\n"
         "end\n"
     ).
+
+maybe_expression(Config) when is_list(Config) ->
+    case erl_scan:reserved_word('else') of
+        true ->
+            ?assertFormat(
+                "maybe 1 ?= 1, 2 = 2, 3, ok\nelse 4 -> ok\nend",
+                "maybe\n"
+                "    1 ?= 1,\n"
+                "    2 = 2,\n"
+                "    3,\n"
+                "    ok\n"
+                "else\n"
+                "    4 -> ok\n"
+                "end\n",
+                100
+            ),
+
+            ?assertFormat(
+                "maybe\nok ?= {error, #{extremely_long_name => that_forces_a_break, for_the_expression => because_it_goes_over, the_line => limit}}, ok\nend",
+                "maybe\n"
+                "    ok ?=\n"
+                "        {error, #{\n"
+                "            extremely_long_name => that_forces_a_break,\n"
+                "            for_the_expression => because_it_goes_over,\n"
+                "            the_line => limit\n"
+                "        }},\n"
+                "    ok\n"
+                "end\n",
+                100
+            ),
+
+            ?assertSame(
+                "maybe\n"
+                "    % comment before\n"
+                "    ok ?= ok,\n"
+                "    % comment end\n"
+                "    ok\n"
+                "else\n"
+                "    % comment else before\n"
+                "    1 -> ok\n"
+                "    % comment else after\n"
+                "end\n"
+            ),
+
+            ok;
+        false ->
+            {skipped, maybe_expr_disabled}
+    end.
 
 receive_expression(Config) when is_list(Config) ->
     ?assertFormat(


### PR DESCRIPTION
Resolves #348

I would've preferred to pass a compiler option to `erl_scan:tokens/4` or something similar, but that does not seem to exist. Therefore this change currently requires the environment variable `ERL_AFLAGS="-enable-feature all"` to be set. I'd love to hear a better solution.

If the environment variable is set, various other things break. This PR addresses them es well.