### PR TITLE
Support for OTP 27 Sigils & Triple Quoted Strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           - os: ubuntu-22.04
             otp-version: 26
             rebar3-version: 3.22
+          - os: ubuntu-22.04
+            otp-version: 27
+            rebar3-version: 3.23
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -254,7 +254,7 @@ do_expr_to_algebra({clauses, _Meta, Clauses}) ->
     clauses_to_algebra(Clauses);
 do_expr_to_algebra({body, _Meta, Exprs}) ->
     block_to_algebra(Exprs);
-do_expr_to_algebra({sigil, _Meta, {Prefix, Content, Suffix}}) ->
+do_expr_to_algebra({sigil, _Meta, Prefix, Content, Suffix}) ->
     concat(
         concat(
             concat(<<"~">>, do_expr_to_algebra(Prefix)),

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -608,7 +608,7 @@ atomic -> string : '$1'.
 atomic -> string concatables : {concat, ?range_anno('$1', '$2'), ['$1' | ?val('$2')]}.
 atomic -> macro_call_none concatables : {concat, ?range_anno('$1', '$2'), ['$1' | ?val('$2')]}.
 atomic -> macro_string concatables : {concat, ?range_anno('$1', '$2'), ['$1' | ?val('$2')]}.
-atomic -> sigil_prefix string sigil_suffix : {sigil, ?range_anno('$1', '$3'), {'$1', '$2', '$3'}}.
+atomic -> sigil_prefix string sigil_suffix : {sigil, ?range_anno('$1', '$3'), '$1', '$2', '$3'}.
 
 concatables_no_initial_call -> concatable_no_call concatables : {['$1' | ?val('$2')], ?anno('$2')}.
 concatables_no_initial_call -> concatable_no_call : {['$1'], ?anno('$1')}.

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -62,7 +62,8 @@ char integer float atom string var
 '<<' '>>'
 '?' '!' '=' '::' '..' '...'
 spec callback define_expr define_type define_clause standalone_exprs % helper
-dot.
+dot
+sigil_prefix sigil_suffix.
 
 %% Conflict comes from optional parens on macro calls.
 Expect 1.
@@ -607,6 +608,7 @@ atomic -> string : '$1'.
 atomic -> string concatables : {concat, ?range_anno('$1', '$2'), ['$1' | ?val('$2')]}.
 atomic -> macro_call_none concatables : {concat, ?range_anno('$1', '$2'), ['$1' | ?val('$2')]}.
 atomic -> macro_string concatables : {concat, ?range_anno('$1', '$2'), ['$1' | ?val('$2')]}.
+atomic -> sigil_prefix string sigil_suffix : {sigil, ?range_anno('$1', '$3'), {'$1', '$2', '$3'}}.
 
 concatables_no_initial_call -> concatable_no_call concatables : {['$1' | ?val('$2')], ?anno('$2')}.
 concatables_no_initial_call -> concatable_no_call : {['$1'], ?anno('$1')}.

--- a/src/erlfmt_scan.erl
+++ b/src/erlfmt_scan.erl
@@ -235,14 +235,7 @@ drop_initial_white_space(Rest) ->
 
 -spec stringify_tokens([erl_scan:token()]) -> string().
 stringify_tokens(Tokens) ->
-    lists:flatmap(fun stringify_token/1, Tokens).
-
--spec stringify_token(erl_scan:token()) -> string().
-stringify_token(Token) ->
-    case erl_scan:text(Token) of
-        undefined -> "";
-        Text -> Text
-    end.
+    lists:flatmap(fun erl_scan:text/1, Tokens).
 
 -spec split_tokens([erl_scan:token()], [erl_scan:token()]) ->
     {[token()], [erl_scan:token()], [comment()], [token()]}.

--- a/src/erlfmt_scan.erl
+++ b/src/erlfmt_scan.erl
@@ -235,7 +235,14 @@ drop_initial_white_space(Rest) ->
 
 -spec stringify_tokens([erl_scan:token()]) -> string().
 stringify_tokens(Tokens) ->
-    lists:flatmap(fun erl_scan:text/1, Tokens).
+    lists:flatmap(fun stringify_token/1, Tokens).
+
+-spec stringify_token(erl_scan:token()) -> string().
+stringify_token(Token) ->
+    case erl_scan:text(Token) of
+        undefined -> "";
+        Text -> Text
+    end.
 
 -spec split_tokens([erl_scan:token()], [erl_scan:token()]) ->
     {[token()], [erl_scan:token()], [comment()], [token()]}.
@@ -315,7 +322,9 @@ atomic_anno([{text, Text}, {location, {Line, Col} = Location}]) ->
     #{text => Text, location => Location, end_location => end_location(Text, Line, Col)}.
 
 token_anno([{text, Text}, {location, {Line, Col} = Location}]) ->
-    #{location => Location, end_location => end_location(Text, Line, Col)}.
+    #{location => Location, end_location => end_location(Text, Line, Col)};
+token_anno({_Line, _Col} = Location) ->
+    #{location => Location, end_location => Location}.
 
 comment_anno([{text, _}, {location, Location}], [{text, Text}, {location, {Line, Col}}]) ->
     #{location => Location, end_location => end_location(Text, Line, Col)}.

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -86,6 +86,13 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
+init_per_group(otp_27_features, Config) ->
+    case erlang:system_info(otp_release) >= "27" of
+        true -> Config;
+        false -> {skip, "Skipping tests for features from OTP >= 27"}
+    end;
+init_per_group(_, Config) ->
+    Config;
 init_per_group(_GroupName, Config) ->
     Config.
 
@@ -121,8 +128,6 @@ groups() ->
             try_expression,
             if_expression,
             macro,
-            sigils,
-            doc_attributes,
             doc_macros
         ]},
         {forms, [parallel], [
@@ -163,6 +168,10 @@ groups() ->
             list_comprehension,
             map_comprehension,
             binary_comprehension
+        ]},
+        {otp_27_features, [parallel], [
+            sigils,
+            doc_attributes
         ]}
     ].
 
@@ -238,7 +247,6 @@ literals(Config) when is_list(Config) ->
     ?assertSame("_Bar\n"),
     ?assertFormat("$ ", "$\\s\n").
 
--if(?OTP_RELEASE >= 27).
 sigils(Config) when is_list(Config) ->
     %% https://www.erlang.org/blog/highlights-otp-27/#sigils
     ?assertSame("~b\"abc\\txyz\"\n"),
@@ -257,10 +265,6 @@ sigils(Config) when is_list(Config) ->
     ),
     ?assertSame("\"\"\"\nTest\nMultiline\n\"\"\"\n"),
     ?assertSame("~\"\"\"\nTest\nMultiline\n\"\"\"\n").
--else.
-sigils(Config) when is_list(Config) ->
-    {skip, "Sigils are supported in OTP >= 27"}.
--endif.
 
 dotted(Config) when is_list(Config) ->
     ?assertSame("<0.1.2>\n"),
@@ -4265,16 +4269,11 @@ comment(Config) when is_list(Config) ->
         "\"b\".\n"
     ).
 
--if(?OTP_RELEASE >= 27).
 doc_attributes(Config) when is_list(Config) ->
     ?assertSame("-moduledoc(\"Test\").\n-moduledoc(#{since => <<\"1.0.0\">>}).\n"),
     ?assertSame("-moduledoc(\"\"\"\nTest\nMultiline\n\"\"\").\n"),
     ?assertSame("-doc(\"Test\").\n-doc(#{since => <<\"1.0.0\">>}).\ntest() -> ok.\n"),
     ?assertSame("-doc(\"Test\").\n-doc(#{since => <<\"1.0.0\">>}).\n-type t() :: ok.\n").
--else.
-doc_attributes(Config) when is_list(Config) ->
-    {skip, "Doc Attributes are supported in OTP >= 27"}.
--endif.
 
 doc_macros(Config) when is_list(Config) ->
     %% Doc Attributes as macros is a common pattern for OTP < 27 compatibility.


### PR DESCRIPTION
Sigils: https://www.erlang.org/blog/highlights-otp-27/#sigils
Triple Quoted Strings: https://www.erlang.org/blog/highlights-otp-27/#triple-quoted-strings

Also adds tests for documentation attributes. See: https://www.erlang.org/blog/highlights-otp-27/#overhauled-documentation-system

Resolves #355