### PR TITLE
Allow providing an optional reason when using erlfmt-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,10 @@ which after re-formatting will result in the original layout again.
 ## Ignoring Formatting
 
 We found that mostly it is possible to format erlang code in an at least somewhat acceptable way, but exceptions do occur.
-We have introduced the `erlfmt-ignore` comment, which when placed before a top-level expression, will indicate to `erlfmt` to skip over that expression, leave it as is and move on to the next expression.
+We have introduced the `erlfmt-ignore` comment, which when placed before a top-level expression, will indicate to `erlfmt` to skip over that expression, leave it as is and move on to the next expression. For documentation purposes, a reason for not formatting can be given..
 
 ```erlang formatted matrix
-%% erlfmt-ignore
+%% erlfmt-ignore I like it more this way
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],

--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -555,17 +555,22 @@ ignore_state([{comment, Loc, Comments} | Rest], FileName, Acc) ->
 ignore_state([], _FileName, Acc) ->
     Acc.
 
+-define(IS_IGNORE_REASON(S), (S =:= [] orelse hd(S) =:= 32 orelse hd(S) =:= $%)).
+
 ignore_state([Line | Lines], FileName, Loc, Rest, Acc0) ->
     Acc =
-        case string:trim(Line, both, "% ") of
-            "erlfmt-ignore" when Acc0 =:= false -> ignore;
-            "erlfmt-ignore" ->
+        case string:trim(Line, leading, "% ") of
+            "erlfmt-ignore" ++ R when ?IS_IGNORE_REASON(R), Acc0 =:= false ->
+                ignore;
+            "erlfmt-ignore" ++ R when ?IS_IGNORE_REASON(R) ->
                 throw({error, {FileName, Loc, ?MODULE, {invalid_ignore, ignore, Acc0}}});
-            "erlfmt-ignore-begin" when Acc0 =:= false -> 'begin';
-            "erlfmt-ignore-begin" ->
+            "erlfmt-ignore-begin" ++ R when ?IS_IGNORE_REASON(R), Acc0 =:= false ->
+                'begin';
+            "erlfmt-ignore-begin" ++ R when ?IS_IGNORE_REASON(R) ->
                 throw({error, {FileName, Loc, ?MODULE, {invalid_ignore, 'begin', Acc0}}});
-            "erlfmt-ignore-end" when Acc0 =:= 'begin' -> 'end';
-            "erlfmt-ignore-end" ->
+            "erlfmt-ignore-end" ++ R when ?IS_IGNORE_REASON(R), Acc0 =:= 'begin' ->
+                'end';
+            "erlfmt-ignore-end" ++ R when ?IS_IGNORE_REASON(R) ->
                 throw({error, {FileName, Loc, ?MODULE, {invalid_ignore, 'end', Acc0}}});
             _ ->
                 Acc0

--- a/test/erlfmt_SUITE_data/ignore_format.erl
+++ b/test/erlfmt_SUITE_data/ignore_format.erl
@@ -33,5 +33,8 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
+% erlfmt-ignore I like the comment next to the statement
+f() -> ok. % this is ok
+
 %% TODO write emit
 emit(S) ->   ok.

--- a/test/erlfmt_SUITE_data/ignore_format.erl.formatted
+++ b/test/erlfmt_SUITE_data/ignore_format.erl.formatted
@@ -33,5 +33,8 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
+% erlfmt-ignore I like the comment next to the statement
+f() -> ok. % this is ok
+
 %% TODO write emit
 emit(S) -> ok.

--- a/test/erlfmt_SUITE_data/ignore_format_many.erl
+++ b/test/erlfmt_SUITE_data/ignore_format_many.erl
@@ -35,5 +35,12 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
+% erlfmt-ignore-begin I like the comments next to the statement
+f() -> ok. % this is ok
+g() -> ok. % this is also ok
+% erlfmt-ignore-end I'm done with this style
+
+h() -> ok. % blah
+
 %% TODO write emit
 emit(S) ->   ok.

--- a/test/erlfmt_SUITE_data/ignore_format_many.erl.formatted
+++ b/test/erlfmt_SUITE_data/ignore_format_many.erl.formatted
@@ -35,5 +35,13 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
+% erlfmt-ignore-begin I like the comments next to the statement
+f() -> ok. % this is ok
+g() -> ok. % this is also ok
+% erlfmt-ignore-end I'm done with this style
+
+% blah
+h() -> ok.
+
 %% TODO write emit
 emit(S) -> ok.


### PR DESCRIPTION
Right now only trailing spaces and `%` are allowed in an `erlfmt-ignore`. We make it so that anything after the `erlfmt-ignore` is discarded, effectively allowing for the user to document why formatting is disabled