### PR TITLE
Allow erlfmt:ignore to be used in addition to erlfmt-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,10 @@ which after re-formatting will result in the original layout again.
 ## Ignoring Formatting
 
 We found that mostly it is possible to format erlang code in an at least somewhat acceptable way, but exceptions do occur.
-We have introduced the `erlfmt-ignore` comment, which when placed before a top-level expression, will indicate to `erlfmt` to skip over that expression, leave it as is and move on to the next expression. For documentation purposes, a reason for not formatting can be given..
+We have introduced the `erlfmt:ignore` comment, which when placed before a top-level expression, will indicate to `erlfmt` to skip over that expression, leave it as is and move on to the next expression. For documentation purposes, a reason for not formatting can be given..
 
 ```erlang formatted matrix
-%% erlfmt-ignore I like it more this way
+%% erlfmt:ignore I like it more this way
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -372,16 +372,16 @@ We have introduced the `erlfmt-ignore` comment, which when placed before a top-l
 ]).
 ```
 
-You can also encose multiple top-level forms in a `erlfmt-ignore-begin`, `erlfmt-ignore-end` section.
+You can also encose multiple top-level forms in a `erlfmt:ignore-begin`, `erlfmt:ignore-end` section.
 ```erlang formatted ignore-many
-%% erlfmt-ignore-begin
+%% erlfmt:ignore-begin
 -define(DELTA_MATRIX1, [
     [0,   0,   0,   0,   0,   0]
 ]).
 -define(DELTA_MATRIX2, [
     [0,   0,   0,   0,   0,   0]
 ]).
-%% erlfmt-ignore-end
+%% erlfmt:ignore-end
 
 -define(THIS_IS_FORMATTED, ok).
 ```

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -68,12 +68,19 @@
     snapshot_script/1,
     snapshot_ignore_format/1,
     snapshot_ignore_format_many/1,
+    snapshot_ignore_format_old/1,
+    snapshot_ignore_format_many_old/1,
     snapshot_empty/1,
     format_string_unicode/1,
     error_ignore_begin_ignore/1,
     error_ignore_begin_ignore_begin/1,
     error_ignore_end/1,
     error_ignore_ignore/1,
+    error_ignore_ignore_old/1,
+    error_ignore_begin_ignore_old/1,
+    error_ignore_begin_ignore_begin_old/1,
+    error_ignore_end_old/1,
+    error_ignore_ignore_old/1,
     simple_comments_range/1,
     broken_range/1,
     snapshot_range_whole_comments/1,
@@ -163,6 +170,8 @@ groups() ->
             snapshot_script,
             snapshot_ignore_format,
             snapshot_ignore_format_many,
+            snapshot_ignore_format_old,
+            snapshot_ignore_format_many_old,
             snapshot_empty,
             format_string_unicode
         ]},
@@ -170,7 +179,11 @@ groups() ->
             error_ignore_begin_ignore,
             error_ignore_begin_ignore_begin,
             error_ignore_end,
-            error_ignore_ignore
+            error_ignore_ignore,
+            error_ignore_begin_ignore_old,
+            error_ignore_begin_ignore_begin_old,
+            error_ignore_end_old,
+            error_ignore_ignore_old
         ]},
         {range_tests, [parallel], [
             simple_comments_range,
@@ -1078,6 +1091,10 @@ snapshot_ignore_format(Config) -> snapshot_formatted("ignore_format.erl", Config
 
 snapshot_ignore_format_many(Config) -> snapshot_formatted("ignore_format_many.erl", Config).
 
+snapshot_ignore_format_old(Config) -> snapshot_formatted("ignore_format_old.erl", Config).
+
+snapshot_ignore_format_many_old(Config) -> snapshot_formatted("ignore_format_many_old.erl", Config).
+
 snapshot_empty(Config) -> snapshot_same("empty.erl", Config).
 
 snapshot_insert_pragma_with(Config) when is_list(Config) ->
@@ -1114,13 +1131,29 @@ format_string_unicode(_) ->
 
 error_ignore_begin_ignore(_) ->
     assert_error(
+        "% erlfmt:ignore-begin\n"
+        "% erlfmt:ignore\n"
+        "foo() -> ok.\n",
+        "nofile:1:1: invalid erlfmt:ignore while in erlfmt:ignore-begin section"
+    ).
+
+error_ignore_begin_ignore_old(_) ->
+    assert_error(
         "% erlfmt-ignore-begin\n"
         "% erlfmt-ignore\n"
         "foo() -> ok.\n",
-        "nofile:1:1: invalid erlfmt-ignore while in erlfmt-ignore-begin section"
+        "nofile:1:1: invalid erlfmt:ignore while in erlfmt:ignore-begin section"
     ).
 
 error_ignore_begin_ignore_begin(_) ->
+    assert_error(
+        "% erlfmt:ignore-begin\n"
+        "% erlfmt:ignore-begin\n"
+        "foo() -> ok.\n",
+        "nofile:1:1: duplicate ignore comment"
+    ).
+
+error_ignore_begin_ignore_begin_old(_) ->
     assert_error(
         "% erlfmt-ignore-begin\n"
         "% erlfmt-ignore-begin\n"
@@ -1130,12 +1163,27 @@ error_ignore_begin_ignore_begin(_) ->
 
 error_ignore_end(_) ->
     assert_error(
+        "% erlfmt:ignore-end\n"
+        "foo() -> ok.\n",
+        "nofile:1:1: invalid erlfmt:ignore-end while outside of erlfmt:ignore-begin section"
+    ).
+
+error_ignore_end_old(_) ->
+    assert_error(
         "% erlfmt-ignore-end\n"
         "foo() -> ok.\n",
-        "nofile:1:1: invalid erlfmt-ignore-end while outside of erlfmt-ignore-begin section"
+        "nofile:1:1: invalid erlfmt:ignore-end while outside of erlfmt:ignore-begin section"
     ).
 
 error_ignore_ignore(_) ->
+    assert_error(
+        "% erlfmt:ignore\n"
+        "% erlfmt:ignore\n"
+        "foo() -> ok.\n",
+        "nofile:1:1: duplicate ignore comment"
+    ).
+
+error_ignore_ignore_old(_) ->
     assert_error(
         "% erlfmt-ignore\n"
         "% erlfmt-ignore\n"

--- a/test/erlfmt_SUITE_data/ignore_format.erl
+++ b/test/erlfmt_SUITE_data/ignore_format.erl
@@ -1,6 +1,6 @@
 -module(ignore_format).
 
-%%% erlfmt-ignore
+%%% erlfmt:ignore
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -20,7 +20,7 @@
 ]).
 
 %% some comment
-%%erlfmt-ignore %
+%%erlfmt:ignore %
 %% another comment
 gen_part_decode_funcs({constructed,bif},TypeName,
               {_Name,parts,Tag,_Type}) ->
@@ -33,7 +33,7 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
-% erlfmt-ignore I like the comment next to the statement
+% erlfmt:ignore I like the comment next to the statement
 f() -> ok. % this is ok
 
 %% TODO write emit

--- a/test/erlfmt_SUITE_data/ignore_format_many.erl
+++ b/test/erlfmt_SUITE_data/ignore_format_many.erl
@@ -1,6 +1,6 @@
 -module(ignore_format_many).
 
-%%% erlfmt-ignore-begin
+%%% erlfmt:ignore-begin
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -11,7 +11,7 @@
 ]).
 -define(ALSO_IGNORED, [  1,  2,  3]).
 
-%%% erlfmt-ignore-end
+%%% erlfmt:ignore-end
 -define(DELTA_MATRIX_FORMATTED, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -22,7 +22,7 @@
 ]).
 
 %% some comment
-%%erlfmt-ignore %
+%%erlfmt:ignore %
 %% another comment
 gen_part_decode_funcs({constructed,bif},TypeName,
               {_Name,parts,Tag,_Type}) ->
@@ -35,10 +35,10 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
-% erlfmt-ignore-begin I like the comments next to the statement
+% erlfmt:ignore-begin I like the comments next to the statement
 f() -> ok. % this is ok
 g() -> ok. % this is also ok
-% erlfmt-ignore-end I'm done with this style
+% erlfmt:ignore-end I'm done with this style
 
 h() -> ok. % blah
 

--- a/test/erlfmt_SUITE_data/ignore_format_many.erl.formatted
+++ b/test/erlfmt_SUITE_data/ignore_format_many.erl.formatted
@@ -1,6 +1,6 @@
 -module(ignore_format_many).
 
-%%% erlfmt-ignore-begin
+%%% erlfmt:ignore-begin
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -11,7 +11,7 @@
 ]).
 -define(ALSO_IGNORED, [  1,  2,  3]).
 
-%%% erlfmt-ignore-end
+%%% erlfmt:ignore-end
 -define(DELTA_MATRIX_FORMATTED, [
     [0, 0, 0, 0, 0, 0],
     [0, -16, 0, 0, 0, 0],
@@ -22,7 +22,7 @@
 ]).
 
 %% some comment
-%%erlfmt-ignore %
+%%erlfmt:ignore %
 %% another comment
 gen_part_decode_funcs({constructed,bif},TypeName,
               {_Name,parts,Tag,_Type}) ->
@@ -35,10 +35,10 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
-% erlfmt-ignore-begin I like the comments next to the statement
+% erlfmt:ignore-begin I like the comments next to the statement
 f() -> ok. % this is ok
 g() -> ok. % this is also ok
-% erlfmt-ignore-end I'm done with this style
+% erlfmt:ignore-end I'm done with this style
 
 % blah
 h() -> ok.

--- a/test/erlfmt_SUITE_data/ignore_format_many_old.erl
+++ b/test/erlfmt_SUITE_data/ignore_format_many_old.erl
@@ -1,6 +1,6 @@
--module(ignore_format).
+-module(ignore_format_many_old).
 
-%%% erlfmt:ignore
+%%% erlfmt-ignore-begin
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -9,18 +9,20 @@
     [0, -16,   0,   0, -14,   0],
     [0,   0,  15,   0,   0,   0]
 ]).
+-define(ALSO_IGNORED, [  1,  2,  3]).
 
+%%% erlfmt-ignore-end
 -define(DELTA_MATRIX_FORMATTED, [
-    [0, 0, 0, 0, 0, 0],
-    [0, -16, 0, 0, 0, 0],
-    [0, 0, 15, 0, 0, 0],
-    [0, 0, 0, 6, 0, 0],
-    [0, -16, 0, 0, -14, 0],
-    [0, 0, 15, 0, 0, 0]
+    [0,   0,   0,   0,   0,   0],
+    [0, -16,   0,   0,   0,   0],
+    [0,   0,  15,   0,   0,   0],
+    [0,   0,   0,   6,   0,   0],
+    [0, -16,   0,   0, -14,   0],
+    [0,   0,  15,   0,   0,   0]
 ]).
 
 %% some comment
-%%erlfmt:ignore %
+%%erlfmt-ignore %
 %% another comment
 gen_part_decode_funcs({constructed,bif},TypeName,
               {_Name,parts,Tag,_Type}) ->
@@ -33,8 +35,12 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
-% erlfmt:ignore I like the comment next to the statement
+% erlfmt-ignore-begin I like the comments next to the statement
 f() -> ok. % this is ok
+g() -> ok. % this is also ok
+% erlfmt-ignore-end I'm done with this style
+
+h() -> ok. % blah
 
 %% TODO write emit
-emit(S) -> ok.
+emit(S) ->   ok.

--- a/test/erlfmt_SUITE_data/ignore_format_many_old.erl.formatted
+++ b/test/erlfmt_SUITE_data/ignore_format_many_old.erl.formatted
@@ -1,6 +1,6 @@
--module(ignore_format).
+-module(ignore_format_many_old).
 
-%%% erlfmt:ignore
+%%% erlfmt-ignore-begin
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -9,7 +9,9 @@
     [0, -16,   0,   0, -14,   0],
     [0,   0,  15,   0,   0,   0]
 ]).
+-define(ALSO_IGNORED, [  1,  2,  3]).
 
+%%% erlfmt-ignore-end
 -define(DELTA_MATRIX_FORMATTED, [
     [0, 0, 0, 0, 0, 0],
     [0, -16, 0, 0, 0, 0],
@@ -20,7 +22,7 @@
 ]).
 
 %% some comment
-%%erlfmt:ignore %
+%%erlfmt-ignore %
 %% another comment
 gen_part_decode_funcs({constructed,bif},TypeName,
               {_Name,parts,Tag,_Type}) ->
@@ -33,8 +35,13 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
-% erlfmt:ignore I like the comment next to the statement
+% erlfmt-ignore-begin I like the comments next to the statement
 f() -> ok. % this is ok
+g() -> ok. % this is also ok
+% erlfmt-ignore-end I'm done with this style
+
+% blah
+h() -> ok.
 
 %% TODO write emit
 emit(S) -> ok.

--- a/test/erlfmt_SUITE_data/ignore_format_old.erl
+++ b/test/erlfmt_SUITE_data/ignore_format_old.erl
@@ -1,6 +1,6 @@
--module(ignore_format).
+-module(ignore_format_old).
 
-%%% erlfmt:ignore
+%%% erlfmt-ignore
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -11,16 +11,16 @@
 ]).
 
 -define(DELTA_MATRIX_FORMATTED, [
-    [0, 0, 0, 0, 0, 0],
-    [0, -16, 0, 0, 0, 0],
-    [0, 0, 15, 0, 0, 0],
-    [0, 0, 0, 6, 0, 0],
-    [0, -16, 0, 0, -14, 0],
-    [0, 0, 15, 0, 0, 0]
+    [0,   0,   0,   0,   0,   0],
+    [0, -16,   0,   0,   0,   0],
+    [0,   0,  15,   0,   0,   0],
+    [0,   0,   0,   6,   0,   0],
+    [0, -16,   0,   0, -14,   0],
+    [0,   0,  15,   0,   0,   0]
 ]).
 
 %% some comment
-%%erlfmt:ignore %
+%%erlfmt-ignore %
 %% another comment
 gen_part_decode_funcs({constructed,bif},TypeName,
               {_Name,parts,Tag,_Type}) ->
@@ -33,8 +33,8 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
-% erlfmt:ignore I like the comment next to the statement
+% erlfmt-ignore I like the comment next to the statement
 f() -> ok. % this is ok
 
 %% TODO write emit
-emit(S) -> ok.
+emit(S) ->   ok.

--- a/test/erlfmt_SUITE_data/ignore_format_old.erl.formatted
+++ b/test/erlfmt_SUITE_data/ignore_format_old.erl.formatted
@@ -1,6 +1,6 @@
--module(ignore_format).
+-module(ignore_format_old).
 
-%%% erlfmt:ignore
+%%% erlfmt-ignore
 -define(DELTA_MATRIX, [
     [0,   0,   0,   0,   0,   0],
     [0, -16,   0,   0,   0,   0],
@@ -20,7 +20,7 @@
 ]).
 
 %% some comment
-%%erlfmt:ignore %
+%%erlfmt-ignore %
 %% another comment
 gen_part_decode_funcs({constructed,bif},TypeName,
               {_Name,parts,Tag,_Type}) ->
@@ -33,7 +33,7 @@ gen_part_decode_funcs({constructed,bif},TypeName,
           "      Res",nl,
           "  end"]).
 
-% erlfmt:ignore I like the comment next to the statement
+% erlfmt-ignore I like the comment next to the statement
 f() -> ok. % this is ok
 
 %% TODO write emit


### PR DESCRIPTION
This puts erlfmt in line with other tools that use the format `toolname:ignore` to disable warnings, and makes it easier for developers to "guess" the correct incantation