### PR TITLE
Set escript main parameter

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 
 {escript_name, erlfmt}.
 
-{escript_emu_args, "%%! +sbtu +A0 -noinput -noshell -mode minimal\n"}.
+{escript_emu_args, "%%! +sbtu +A0 -noinput -noshell -mode minimal -escript main erlfmt\n"}.
 
 {minimum_otp_vsn, "21"}.
 


### PR DESCRIPTION
If this parameter is not specified explicitly, erlfmt cannot be installed under a non-standard name:

    % cp _build/release/bin/erlfmt erlfmt-1.5.0
    % ./erlfmt-1.5.0
    escript: exception error: undefined function 'erlfmt-1.5':main/1
    ...