### PR TITLE
Fix bug where two contiguous ignore-begin blocks results in an error

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -538,15 +538,11 @@ parse(Tokens) ->
     end.
 
 ignore_state_pre(PreComments, FileName, Acc) ->
-    case ignore_state(PreComments, FileName, Acc) of
-        'end' -> false;
-        Other -> Other
-    end.
+    ignore_state(PreComments, FileName, Acc).
 
 ignore_state_post(PostComments, FileName, Acc) ->
     case ignore_state(PostComments, FileName, Acc) of
         ignore -> false;
-        'end' -> false;
         Other -> Other
     end.
 
@@ -570,7 +566,7 @@ ignore_state([Line | Lines], FileName, Loc, Rest, Acc0) ->
             "erlfmt-ignore-begin" ++ R when ?IS_IGNORE_REASON(R) ->
                 throw({error, {FileName, Loc, ?MODULE, {invalid_ignore, 'begin', Acc0}}});
             "erlfmt-ignore-end" ++ R when ?IS_IGNORE_REASON(R), Acc0 =:= 'begin' ->
-                'end';
+                false;
             "erlfmt-ignore-end" ++ R when ?IS_IGNORE_REASON(R) ->
                 throw({error, {FileName, Loc, ?MODULE, {invalid_ignore, 'end', Acc0}}});
             % New-style erlfmt:ignore
@@ -583,7 +579,7 @@ ignore_state([Line | Lines], FileName, Loc, Rest, Acc0) ->
             "erlfmt:ignore-begin" ++ R when ?IS_IGNORE_REASON(R) ->
                 throw({error, {FileName, Loc, ?MODULE, {invalid_ignore, 'begin', Acc0}}});
             "erlfmt:ignore-end" ++ R when ?IS_IGNORE_REASON(R), Acc0 =:= 'begin' ->
-                'end';
+                false;
             "erlfmt:ignore-end" ++ R when ?IS_IGNORE_REASON(R) ->
                 throw({error, {FileName, Loc, ?MODULE, {invalid_ignore, 'end', Acc0}}});
             _ ->

--- a/test/erlfmt_SUITE_data/ignore_format_many.erl
+++ b/test/erlfmt_SUITE_data/ignore_format_many.erl
@@ -40,6 +40,11 @@ f() -> ok. % this is ok
 g() -> ok. % this is also ok
 % erlfmt:ignore-end I'm done with this style
 
+% erlfmt:ignore-begin Here we go again...
+a1() -> ok. % again
+a2() -> ok. % ditto
+% erlfmt:ignore-end Now I'm really done
+
 h() -> ok. % blah
 
 %% TODO write emit

--- a/test/erlfmt_SUITE_data/ignore_format_many.erl.formatted
+++ b/test/erlfmt_SUITE_data/ignore_format_many.erl.formatted
@@ -40,6 +40,11 @@ f() -> ok. % this is ok
 g() -> ok. % this is also ok
 % erlfmt:ignore-end I'm done with this style
 
+% erlfmt:ignore-begin Here we go again...
+a1() -> ok. % again
+a2() -> ok. % ditto
+% erlfmt:ignore-end Now I'm really done
+
 % blah
 h() -> ok.
 


### PR DESCRIPTION
Erlfmt currently can't parse two contiguous `erlfmt:ignore-begin` / `erlfmt:ignore-end` blocks. When we parse the first `ignore-end` we leave the formatter in an "end" state and don't clear it before the next "begin" since we don't run `ignore_state_pre` or `ignore_state_post` until the next non-comment. erlfmt doesn't handle transitions from `end` to `begin`, resulting in an error.

After checking the code, it's unclear to me why we need an `end` state in the first place - we always end up transforming it in `false` whenever we start or finish processing a statement. On this PR I'm simplifying things by simply setting the state to `false` after an `erlfmt:ignore-end` statement.

The unit test added fails in master and can be used to confirm the fix.
