### PR TITLE
Bypass file server to improve IO performance

### DIFF
--- a/src/erlfmt.erl
+++ b/src/erlfmt.erl
@@ -416,11 +416,19 @@ read_file(FileName, Action) ->
     end.
 
 % Return file as one big string (with '\n' as line separator).
+-if(?OTP_RELEASE >= 27).
+read_file_or_stdin(stdin) ->
+    read_stdin([]);
+read_file_or_stdin(FileName) ->
+    {ok, Bin} = file:read_file(FileName, [raw]),
+    unicode:characters_to_list(Bin).
+-else.
 read_file_or_stdin(stdin) ->
     read_stdin([]);
 read_file_or_stdin(FileName) ->
     {ok, Bin} = file:read_file(FileName),
     unicode:characters_to_list(Bin).
+-endif.
 
 read_stdin(Acc) ->
     case io:get_line("") of


### PR DESCRIPTION
By default, IO operations are serialised through the file server, which can add significant overhead. Moreover, we don't need the features of a fileserver here (multiple processes accessing a file at once, remote file access, etc.). As such, we bypass this using the `raw` option or the `prim_file` module (depending on context) to get a nice littler performance boost.

Relevant docs: https://www.erlang.org/doc/apps/kernel/file.html#module-performance