### PR TITLE
Fix sigil formatting bug that produced invalid mixed syntax

### DIFF
--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -271,12 +271,6 @@ do_expr_to_algebra({sigil, _Meta, Prefix, {string, ContentMeta, _Value}, Suffix}
         % Multi-line non-triple-quoted sigils need force_breaks
         _ -> concat([force_breaks(), SigilDoc])
     end;
-do_expr_to_algebra({sigil, _Meta, Prefix, {Atomic, ContentMeta, _Value}, Suffix}) when
-    ?IS_ATOMIC(Atomic)
-->
-    PrefixDoc = concat(<<"~">>, do_expr_to_algebra(Prefix)),
-    Text = erlfmt_scan:get_anno(text, ContentMeta),
-    concat(concat(PrefixDoc, string(Text)), do_expr_to_algebra(Suffix));
 do_expr_to_algebra({sigil_prefix, _Meta, ''}) ->
     <<"">>;
 do_expr_to_algebra({sigil_prefix, _Meta, SigilName}) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -259,9 +259,12 @@ do_expr_to_algebra({clauses, _Meta, Clauses}) ->
     clauses_to_algebra(Clauses);
 do_expr_to_algebra({body, _Meta, Exprs}) ->
     block_to_algebra(Exprs);
-do_expr_to_algebra({sigil, _Meta, Prefix, Content, Suffix}) ->
+do_expr_to_algebra({sigil, _Meta, Prefix, {Atomic, ContentMeta, _Value}, Suffix}) when
+    ?IS_ATOMIC(Atomic)
+->
     PrefixDoc = concat(<<"~">>, do_expr_to_algebra(Prefix)),
-    concat(concat(PrefixDoc, do_expr_to_algebra(Content)), do_expr_to_algebra(Suffix));
+    Text = erlfmt_scan:get_anno(text, ContentMeta),
+    concat(concat(PrefixDoc, string(Text)), do_expr_to_algebra(Suffix));
 do_expr_to_algebra({sigil_prefix, _Meta, ''}) ->
     <<"">>;
 do_expr_to_algebra({sigil_prefix, _Meta, SigilName}) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -264,11 +264,9 @@ do_expr_to_algebra({sigil, _Meta, Prefix, {string, ContentMeta, _Value}, Suffix}
     Text = erlfmt_scan:get_anno(text, ContentMeta),
     SigilDoc = concat(concat(PrefixDoc, string(Text)), do_expr_to_algebra(Suffix)),
     case string:split(Text, "\n", all) of
-        % Triple-quoted sigils don't need force_breaks
-        ["\"\"\"" ++ _ | _] -> SigilDoc;
         % Single-line sigils don't need force_breaks
         [_] -> SigilDoc;
-        % Multi-line non-triple-quoted sigils need force_breaks
+        % Multi-line sigils (including triple-quoted) need force_breaks for containers
         _ -> concat([force_breaks(), SigilDoc])
     end;
 do_expr_to_algebra({sigil_prefix, _Meta, ''}) ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -264,7 +264,11 @@ do_expr_to_algebra({sigil, _Meta, Prefix, {Atomic, ContentMeta, _Value}, Suffix}
 ->
     PrefixDoc = concat(<<"~">>, do_expr_to_algebra(Prefix)),
     Text = erlfmt_scan:get_anno(text, ContentMeta),
-    concat(concat(PrefixDoc, string(Text)), do_expr_to_algebra(Suffix));
+    SigilDoc = concat(concat(PrefixDoc, string(Text)), do_expr_to_algebra(Suffix)),
+    case string:find(Text, "\n") of
+        nomatch -> SigilDoc;
+        _ -> concat([force_breaks(), SigilDoc])
+    end;
 do_expr_to_algebra({sigil_prefix, _Meta, ''}) ->
     <<"">>;
 do_expr_to_algebra({sigil_prefix, _Meta, SigilName}) ->

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -307,36 +307,59 @@ sigils(Config) when is_list(Config) ->
         "    \"\n"
         "].\n"
     ),
-    %% Triple-quoted sigils don't cause container breaks (they handle indentation properly)
+    %% Triple-quoted sigils cause container breaks like regular multiline sigils
     ?assertSame(
-        "[~\"\"\"\n"
+        "[\n"
+        "    ~\"\"\"\n"
         "    foo\n"
         "    bar\n"
-        "    \"\"\"].\n"
+        "    \"\"\"\n"
+        "].\n"
     ),
-    %% Triple-quoted sigils with prefixes also don't break containers
-    ?assertSame(
+    %% Triple-quoted sigils with prefixes also break containers
+    ?assertFormat(
         "[~s\"\"\"\n"
         "    content\n"
         "    with prefix\n"
-        "    \"\"\"].\n"
+        "    \"\"\"].\n",
+        "[\n"
+        "    ~s\"\"\"\n"
+        "    content\n"
+        "    with prefix\n"
+        "    \"\"\"\n"
+        "].\n"
     ),
-    %% Triple-quoted sigils in tuples don't break containers
-    ?assertSame(
+    %% Triple-quoted sigils in tuples break containers
+    ?assertFormat(
         "{~\"\"\"\n"
         "    tuple content\n"
-        "    \"\"\", other}.\n"
+        "    \"\"\", other}.\n",
+        "{\n"
+        "    ~\"\"\"\n"
+        "    tuple content\n"
+        "    \"\"\",\n"
+        "    other\n"
+        "}.\n"
     ),
-    %% Triple-quoted sigils in function calls don't break containers
-    ?assertSame(
+    %% Triple-quoted sigils in function calls break containers
+    ?assertFormat(
         "process(~\"\"\"\n"
         "    function arg\n"
-        "    \"\"\").\n"
+        "    \"\"\").\n",
+        "process(\n"
+        "    ~\"\"\"\n"
+        "    function arg\n"
+        "    \"\"\"\n"
+        ").\n"
     ),
-    %% Edge case: minimal triple-quoted sigil content
-    ?assertSame(
+    %% Edge case: minimal triple-quoted sigil content still breaks containers
+    ?assertFormat(
         "[~\"\"\"\n"
-        "\"\"\"].\n"
+        "\"\"\"].\n",
+        "[\n"
+        "    ~\"\"\"\n"
+        "\"\"\"\n"
+        "].\n"
     ),
     %% Mixed triple-quoted and regular multiline sigils show different behavior
     ?assertFormat(

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -307,6 +307,26 @@ sigils(Config) when is_list(Config) ->
     ),
     %% Triple-quoted sigils don't cause container breaks (they handle indentation properly)
     ?assertSame("[~\"\"\"\n    foo\n    bar\n    \"\"\"].\n"),
+    %% Triple-quoted sigils with prefixes also don't break containers
+    ?assertSame("[~s\"\"\"\n    content\n    with prefix\n    \"\"\"].\n"),
+    %% Triple-quoted sigils in tuples don't break containers
+    ?assertSame("{~\"\"\"\n    tuple content\n    \"\"\", other}.\n"),
+    %% Triple-quoted sigils in function calls don't break containers
+    ?assertSame("process(~\"\"\"\n    function arg\n    \"\"\").\n"),
+    %% Edge case: minimal triple-quoted sigil content
+    ?assertSame("[~\"\"\"\n\"\"\"].\n"),
+    %% Mixed triple-quoted and regular multiline sigils show different behavior
+    ?assertFormat(
+        "[~\"\"\"\n    triple quoted\n    \"\"\", ~\"\n    regular multiline\n    \"].\n",
+        "[\n"
+        "    ~\"\"\"\n"
+        "    triple quoted\n"
+        "    \"\"\",\n"
+        "    ~\"\n"
+        "    regular multiline\n"
+        "    \"\n"
+        "].\n"
+    ),
     %% Test sigils with prefixes and modifiers in lists
     ?assertFormat(
         "[~s\"\n    foo\n    \"].\n",

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -295,7 +295,40 @@ sigils(Config) when is_list(Config) ->
     ),
     ?assertSame("~s\"\"\"\n\\tabc\n\\tdef\n\"\"\"\n"),
     ?assertSame("\"\"\"\nTest\nMultiline\n\"\"\"\n"),
-    ?assertSame("~\"\"\"\nTest\nMultiline\n\"\"\"\n").
+    ?assertSame("~\"\"\"\nTest\nMultiline\n\"\"\"\n"),
+    %% Test multiline sigils in lists - preserves sigils unchanged (no mixed syntax bug)
+    ?assertSame("[~\"\n    foo\n    \"].\n"),
+    ?assertSame("[~\"\"\"\n    foo\n    bar\n    \"\"\"].\n"),
+    %% Test sigils with prefixes and modifiers in lists
+    ?assertSame("[~s\"\n    foo\n    \"].\n"),
+    ?assertSame("[~b\"\n    foo\n    \"x].\n"),
+    %% Test mixed regular and sigil strings in lists
+    ?assertFormat(
+        "[\"regular\n    multiline\", ~\"sigil\n    multiline\"].\n",
+        "[\n"
+        "    \"regular\\n\"\n"
+        "    \"    multiline\",\n"
+        "    ~\"sigil\n    multiline\"\n"
+        "].\n"
+    ),
+    %% Test sigils in tuples
+    ?assertSame("{~\"\n    foo\n    \", bar}.\n"),
+    %% Test sigils in function calls
+    ?assertSame("foo(~\"\n    multiline\n    \").\n"),
+    %% Test sigils in function arguments with other expressions
+    ?assertFormat(
+        "foo(\"regular\n    string\", ~\"sigil\n    string\", atom).\n",
+        "foo(\n"
+        "    \"regular\\n\"\n"
+        "    \"    string\",\n"
+        "    ~\"sigil\n    string\",\n"
+        "    atom\n"
+        ").\n"
+    ),
+    %% Test sigils in maps
+    ?assertSame("#{key => ~\"\n    value\n    \"}.\n"),
+    %% Test sigils in records
+    ?assertSame("#rec{field = ~\"\n    value\n    \"}.\n").
 
 dotted(Config) when is_list(Config) ->
     ?assertSame("<0.1.2>\n"),

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -298,7 +298,9 @@ sigils(Config) when is_list(Config) ->
     ?assertSame("~\"\"\"\nTest\nMultiline\n\"\"\"\n"),
     %% Test multiline sigils in lists cause list to break
     ?assertFormat(
-        "[~\"\n    foo\n    \"].\n",
+        "[~\"\n"
+        "    foo\n"
+        "    \"].\n",
         "[\n"
         "    ~\"\n"
         "    foo\n"
@@ -306,18 +308,43 @@ sigils(Config) when is_list(Config) ->
         "].\n"
     ),
     %% Triple-quoted sigils don't cause container breaks (they handle indentation properly)
-    ?assertSame("[~\"\"\"\n    foo\n    bar\n    \"\"\"].\n"),
+    ?assertSame(
+        "[~\"\"\"\n"
+        "    foo\n"
+        "    bar\n"
+        "    \"\"\"].\n"
+    ),
     %% Triple-quoted sigils with prefixes also don't break containers
-    ?assertSame("[~s\"\"\"\n    content\n    with prefix\n    \"\"\"].\n"),
+    ?assertSame(
+        "[~s\"\"\"\n"
+        "    content\n"
+        "    with prefix\n"
+        "    \"\"\"].\n"
+    ),
     %% Triple-quoted sigils in tuples don't break containers
-    ?assertSame("{~\"\"\"\n    tuple content\n    \"\"\", other}.\n"),
+    ?assertSame(
+        "{~\"\"\"\n"
+        "    tuple content\n"
+        "    \"\"\", other}.\n"
+    ),
     %% Triple-quoted sigils in function calls don't break containers
-    ?assertSame("process(~\"\"\"\n    function arg\n    \"\"\").\n"),
+    ?assertSame(
+        "process(~\"\"\"\n"
+        "    function arg\n"
+        "    \"\"\").\n"
+    ),
     %% Edge case: minimal triple-quoted sigil content
-    ?assertSame("[~\"\"\"\n\"\"\"].\n"),
+    ?assertSame(
+        "[~\"\"\"\n"
+        "\"\"\"].\n"
+    ),
     %% Mixed triple-quoted and regular multiline sigils show different behavior
     ?assertFormat(
-        "[~\"\"\"\n    triple quoted\n    \"\"\", ~\"\n    regular multiline\n    \"].\n",
+        "[~\"\"\"\n"
+        "    triple quoted\n"
+        "    \"\"\", ~\"\n"
+        "    regular multiline\n"
+        "    \"].\n",
         "[\n"
         "    ~\"\"\"\n"
         "    triple quoted\n"
@@ -329,7 +356,9 @@ sigils(Config) when is_list(Config) ->
     ),
     %% Test sigils with prefixes and modifiers in lists
     ?assertFormat(
-        "[~s\"\n    foo\n    \"].\n",
+        "[~s\"\n"
+        "    foo\n"
+        "    \"].\n",
         "[\n"
         "    ~s\"\n"
         "    foo\n"
@@ -337,7 +366,9 @@ sigils(Config) when is_list(Config) ->
         "].\n"
     ),
     ?assertFormat(
-        "[~b\"\n    foo\n    \"x].\n",
+        "[~b\"\n"
+        "    foo\n"
+        "    \"x].\n",
         "[\n"
         "    ~b\"\n"
         "    foo\n"
@@ -346,16 +377,21 @@ sigils(Config) when is_list(Config) ->
     ),
     %% Test mixed regular and sigil strings in lists
     ?assertFormat(
-        "[\"regular\n    multiline\", ~\"sigil\n    multiline\"].\n",
+        "[\"regular\n"
+        "    multiline\", ~\"sigil\n"
+        "    multiline\"].\n",
         "[\n"
         "    \"regular\\n\"\n"
         "    \"    multiline\",\n"
-        "    ~\"sigil\n    multiline\"\n"
+        "    ~\"sigil\n"
+        "    multiline\"\n"
         "].\n"
     ),
     %% Test sigils in tuples
     ?assertFormat(
-        "{~\"\n    foo\n    \", bar}.\n",
+        "{~\"\n"
+        "    foo\n"
+        "    \", bar}.\n",
         "{\n"
         "    ~\"\n"
         "    foo\n"
@@ -365,7 +401,9 @@ sigils(Config) when is_list(Config) ->
     ),
     %% Test sigils in function calls
     ?assertFormat(
-        "foo(~\"\n    multiline\n    \").\n",
+        "foo(~\"\n"
+        "    multiline\n"
+        "    \").\n",
         "foo(\n"
         "    ~\"\n"
         "    multiline\n"
@@ -374,17 +412,22 @@ sigils(Config) when is_list(Config) ->
     ),
     %% Test sigils in function arguments with other expressions
     ?assertFormat(
-        "foo(\"regular\n    string\", ~\"sigil\n    string\", atom).\n",
+        "foo(\"regular\n"
+        "    string\", ~\"sigil\n"
+        "    string\", atom).\n",
         "foo(\n"
         "    \"regular\\n\"\n"
         "    \"    string\",\n"
-        "    ~\"sigil\n    string\",\n"
+        "    ~\"sigil\n"
+        "    string\",\n"
         "    atom\n"
         ").\n"
     ),
     %% Test sigils in maps
     ?assertFormat(
-        "#{key => ~\"\n    value\n    \"}.\n",
+        "#{key => ~\"\n"
+        "    value\n"
+        "    \"}.\n",
         "#{\n"
         "    key =>\n"
         "        ~\"\n"
@@ -394,7 +437,9 @@ sigils(Config) when is_list(Config) ->
     ),
     %% Test sigils in records
     ?assertFormat(
-        "#rec{field = ~\"\n    value\n    \"}.\n",
+        "#rec{field = ~\"\n"
+        "    value\n"
+        "    \"}.\n",
         "#rec{\n"
         "    field =\n"
         "        ~\"\n"

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -296,12 +296,41 @@ sigils(Config) when is_list(Config) ->
     ?assertSame("~s\"\"\"\n\\tabc\n\\tdef\n\"\"\"\n"),
     ?assertSame("\"\"\"\nTest\nMultiline\n\"\"\"\n"),
     ?assertSame("~\"\"\"\nTest\nMultiline\n\"\"\"\n"),
-    %% Test multiline sigils in lists - preserves sigils unchanged (no mixed syntax bug)
-    ?assertSame("[~\"\n    foo\n    \"].\n"),
-    ?assertSame("[~\"\"\"\n    foo\n    bar\n    \"\"\"].\n"),
+    %% Test multiline sigils in lists cause list to break
+    ?assertFormat(
+        "[~\"\n    foo\n    \"].\n",
+        "[\n"
+        "    ~\"\n"
+        "    foo\n"
+        "    \"\n"
+        "].\n"
+    ),
+    ?assertFormat(
+        "[~\"\"\"\n    foo\n    bar\n    \"\"\"].\n",
+        "[\n"
+        "    ~\"\"\"\n"
+        "    foo\n"
+        "    bar\n"
+        "    \"\"\"\n"
+        "].\n"
+    ),
     %% Test sigils with prefixes and modifiers in lists
-    ?assertSame("[~s\"\n    foo\n    \"].\n"),
-    ?assertSame("[~b\"\n    foo\n    \"x].\n"),
+    ?assertFormat(
+        "[~s\"\n    foo\n    \"].\n",
+        "[\n"
+        "    ~s\"\n"
+        "    foo\n"
+        "    \"\n"
+        "].\n"
+    ),
+    ?assertFormat(
+        "[~b\"\n    foo\n    \"x].\n",
+        "[\n"
+        "    ~b\"\n"
+        "    foo\n"
+        "    \"x\n"
+        "].\n"
+    ),
     %% Test mixed regular and sigil strings in lists
     ?assertFormat(
         "[\"regular\n    multiline\", ~\"sigil\n    multiline\"].\n",
@@ -312,9 +341,24 @@ sigils(Config) when is_list(Config) ->
         "].\n"
     ),
     %% Test sigils in tuples
-    ?assertSame("{~\"\n    foo\n    \", bar}.\n"),
+    ?assertFormat(
+        "{~\"\n    foo\n    \", bar}.\n",
+        "{\n"
+        "    ~\"\n"
+        "    foo\n"
+        "    \",\n"
+        "    bar\n"
+        "}.\n"
+    ),
     %% Test sigils in function calls
-    ?assertSame("foo(~\"\n    multiline\n    \").\n"),
+    ?assertFormat(
+        "foo(~\"\n    multiline\n    \").\n",
+        "foo(\n"
+        "    ~\"\n"
+        "    multiline\n"
+        "    \"\n"
+        ").\n"
+    ),
     %% Test sigils in function arguments with other expressions
     ?assertFormat(
         "foo(\"regular\n    string\", ~\"sigil\n    string\", atom).\n",
@@ -326,9 +370,38 @@ sigils(Config) when is_list(Config) ->
         ").\n"
     ),
     %% Test sigils in maps
-    ?assertSame("#{key => ~\"\n    value\n    \"}.\n"),
+    ?assertFormat(
+        "#{key => ~\"\n    value\n    \"}.\n",
+        "#{\n"
+        "    key =>\n"
+        "        ~\"\n"
+        "    value\n"
+        "    \"\n"
+        "}.\n"
+    ),
     %% Test sigils in records
-    ?assertSame("#rec{field = ~\"\n    value\n    \"}.\n").
+    ?assertFormat(
+        "#rec{field = ~\"\n    value\n    \"}.\n",
+        "#rec{\n"
+        "    field =\n"
+        "        ~\"\n"
+        "    value\n"
+        "    \"\n"
+        "}.\n"
+    ),
+    %% Test sigils cause containers to break but preserve sigil content
+    ?assertFormat(
+        "test() ->\n"
+        "    [~\"\n"
+        "    \", b, c].\n",
+        "test() ->\n"
+        "    [\n"
+        "        ~\"\n"
+        "    \",\n"
+        "        b,\n"
+        "        c\n"
+        "    ].\n"
+    ).
 
 dotted(Config) when is_list(Config) ->
     ?assertSame("<0.1.2>\n"),

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -305,15 +305,8 @@ sigils(Config) when is_list(Config) ->
         "    \"\n"
         "].\n"
     ),
-    ?assertFormat(
-        "[~\"\"\"\n    foo\n    bar\n    \"\"\"].\n",
-        "[\n"
-        "    ~\"\"\"\n"
-        "    foo\n"
-        "    bar\n"
-        "    \"\"\"\n"
-        "].\n"
-    ),
+    %% Triple-quoted sigils don't cause container breaks (they handle indentation properly)
+    ?assertSame("[~\"\"\"\n    foo\n    bar\n    \"\"\"].\n"),
     %% Test sigils with prefixes and modifiers in lists
     ?assertFormat(
         "[~s\"\n    foo\n    \"].\n",


### PR DESCRIPTION
Fixes #369

When formatting multiline sigil strings, erlfmt was incorrectly applying regular string transformation logic, creating invalid mixed syntax like:

```erlang
~"\n"
"    foo\n"
"    "
```

This fix leaves the sigil content entirely unchanged to prevent the mixed syntax bug.

I'm not entirely sure if this is the best solution - sigils might still be able to participate in container line-breaking while keeping their raw content intact.

I welcome maintainer feedback on whether full preservation fits erlfmt's formatting philosophy or if an alternative approach would be better.