### PR TITLE
Add support for OTP 29 features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           - os: ubuntu-24.04
             otp-version: 28
             rebar3-version: 3.25
+          - os: ubuntu-24.04
+            otp-version: OTP-29.0-rc1
+            rebar3-version: 3.26
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/doc/erlfmt_parse.md
+++ b/doc/erlfmt_parse.md
@@ -90,3 +90,9 @@ In `erlfmt_parse` the following AST nodes have different definitions:
 * Representation for types is in general the same as for corresponding values.
   The `type` node is not used at all. This means new binary operators inside types
   are defined: `|`, `::`, and `..`.
+
+* Comprehension nodes (`lc`, `mc`, `bc`) always represent the expression(s) before
+  `||` as a list, even for single-value comprehensions. For example, `[X || X <- List]`
+  produces `{lc, Anno, [X], Generators}` and `[I, -I || I <- List]` produces
+  `{lc, Anno, [I, {op, _, '-', I}], Generators}`. In `erl_parse`, single-value
+  comprehensions use a bare expression instead of a list.

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -97,6 +97,9 @@ to_algebra({attribute, Meta, {atom, _, record}, [Name, {tuple, TMeta, Values} = 
             Doc = surround(HeadD, <<"">>, expr_to_algebra(Tuple), <<"">>, <<")">>),
             combine_comments_with_dot(Meta, Doc)
     end;
+to_algebra({attribute, Meta, {atom, _, record}, [RecordExpr]}) ->
+    Doc = concat(<<"-record ">>, expr_to_algebra(RecordExpr)),
+    combine_comments_with_dot(Meta, Doc);
 to_algebra({attribute, Meta, {atom, _, RawName} = Name, [Value]}) when
     RawName =:= doc; RawName =:= moduledoc
 ->

--- a/src/erlfmt_format.erl
+++ b/src/erlfmt_format.erl
@@ -184,12 +184,12 @@ do_expr_to_algebra({record_field, Meta, Expr, Name, Key}) ->
     concat(wrap_if_integer(expr_to_algebra(Expr), Expr), record_access_to_algebra(Meta, Name, Key));
 do_expr_to_algebra({record_name, Meta, Name}) ->
     record_name_to_algebra(Meta, Name);
-do_expr_to_algebra({lc, _Meta, Expr, LcExprs}) ->
-    comprehension_to_algebra(Expr, LcExprs, <<"[">>, <<"]">>);
-do_expr_to_algebra({mc, _Meta, Expr, LcExprs}) ->
-    comprehension_to_algebra(Expr, LcExprs, <<"#{">>, <<"}">>);
-do_expr_to_algebra({bc, _Meta, Expr, LcExprs}) ->
-    comprehension_to_algebra(Expr, LcExprs, <<"<<">>, <<">>">>);
+do_expr_to_algebra({lc, _Meta, Exprs, LcExprs}) ->
+    comprehension_to_algebra(Exprs, LcExprs, <<"[">>, <<"]">>);
+do_expr_to_algebra({mc, _Meta, Exprs, LcExprs}) ->
+    comprehension_to_algebra(Exprs, LcExprs, <<"#{">>, <<"}">>);
+do_expr_to_algebra({bc, _Meta, Exprs, LcExprs}) ->
+    comprehension_to_algebra(Exprs, LcExprs, <<"<<">>, <<">>">>);
 do_expr_to_algebra({generate, _Meta, Op, Left, Right}) ->
     field_to_algebra(atom_to_binary(Op), Left, Right);
 do_expr_to_algebra({call, Meta, Name, Args}) ->
@@ -711,12 +711,15 @@ record_name_to_algebra(Meta, Name) ->
         false -> concat(<<"#">>, expr_to_algebra(Name))
     end.
 
-comprehension_to_algebra(Expr, [LcExpr | _] = LcExprs, Left, Right) ->
-    ExprD = expr_to_algebra(Expr),
+comprehension_to_algebra(Exprs, [LcExpr | _] = LcExprs, Left, Right) ->
+    ExprsD = lists:map(fun expr_to_algebra/1, Exprs),
+    ExprD = group(fold_doc(fun(D, Acc) -> break(concat(D, <<",">>), Acc) end, ExprsD)),
     LcExprsD = lists:map(fun expr_to_algebra/1, LcExprs),
     LcExprD = fold_doc(fun(D, Acc) -> break(concat(D, <<",">>), Acc) end, LcExprsD),
     PostBreak = maybe_force_breaks(has_any_break_between(LcExprs)),
-    PreBreak = concat(maybe_force_breaks(has_break_between(Expr, LcExpr)), break(<<"">>)),
+    PreBreak = concat(
+        maybe_force_breaks(has_break_between(lists:last(Exprs), LcExpr)), break(<<"">>)
+    ),
     IndentExpr = nest(concat(break(<<"">>), ExprD), ?INDENT, break),
     IdentLcs = nest(group(concat(PostBreak, LcExprD)), ?INDENT),
     group(concat([Left, IndentExpr, PreBreak, <<" || ">>, IdentLcs, break(<<"">>), Right])).

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -403,6 +403,9 @@ record_fields -> record_field ',' : ['$1'].
 record_fields -> record_field ',' record_fields : ['$1' | '$3'].
 
 record_field -> record_field_name '=' expr : {record_field,?range_anno('$1', '$3'),'$1','$3'}.
+record_field -> record_field_name '::' type :
+    {op, ?range_anno('$1', '$3'), '::', {record_field,?anno('$1'),'$1'}, '$3'}.
+record_field -> record_field_name : {record_field,?anno('$1'),'$1'}.
 
 record_name -> atom_or_var_or_macro : '$1'.
 
@@ -1150,6 +1153,8 @@ build_macro_def({'-', Anno}, {_, AttrAnno}, {Name, Body}) ->
 
 build_attribute({'-', Anno}, {atom, _, record} = Attr, [Name, Tuple]) ->
     {attribute, Anno, Attr, [Name, record_tuple(Tuple)]};
+build_attribute({'-', Anno}, {atom, _, record} = Attr, Values) ->
+    {attribute, Anno, Attr, Values};
 build_attribute({'-', Anno}, {atom, _, _} = Attr, Values) ->
     {attribute, Anno, Attr, Values};
 build_attribute({'-', Anno}, {Name, NameAnno}, Values) ->

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -408,6 +408,8 @@ record_field -> record_field_name '::' type :
 record_field -> record_field_name : {record_field,?anno('$1'),'$1'}.
 
 record_name -> atom_or_var_or_macro : '$1'.
+record_name -> atom_or_var_or_macro ':' atom_or_var_or_macro :
+    {remote, ?range_anno('$1', '$3'), '$1', '$3'}.
 
 record_field_name -> atom_or_var_or_macro : '$1'.
 

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -51,7 +51,7 @@ macro_name macro_def_expr macro_def_expr_body macro_def_type macro_def_clause.
 Terminals
 char integer float atom string var
 
-'(' ')' ',' '->' '{' '}' '[' ']' '|' '||' '<-' '<:-' ';' ':' '#' '.' '?=' '&&'
+'(' ')' ',' '->' '{' '}' '[' ']' '|' '||' '<-' '<:-' ';' ':' '#' '#_' '.' '?=' '&&'
 'after' 'begin' 'case' 'try' 'catch' 'end' 'fun' 'if' 'of' 'receive' 'when' 'maybe' 'else'
 'andalso' 'orelse'
 'bnot' 'not'
@@ -289,6 +289,8 @@ record_pat_expr -> '#' record_name '.' record_field_name :
         {record_index, ?range_anno('$1', '$4'), '$2', '$4'}.
 record_pat_expr -> '#' record_name record_tuple :
         {record, ?range_anno('$1', '$3'), '$2', ?val('$3')}.
+record_pat_expr -> '#_' record_tuple :
+        {record, ?range_anno('$1', '$2'), any_record_name('$1'), ?val('$2')}.
 
 list -> '[' ']' : {list, ?range_anno('$1', '$2'), []}.
 list -> '[' list_exprs ']' : {list, ?range_anno('$1', '$3'), '$2'}.
@@ -385,6 +387,12 @@ record_expr -> expr_callee '#' record_name '.' record_field_name :
     {record_field, ?range_anno('$1', '$5'), '$1', '$3', '$5'}.
 record_expr -> expr_callee '#' record_name record_tuple :
     {record, ?range_anno('$1', '$4'), '$1', '$3', ?val('$4')}.
+record_expr -> '#_' record_tuple :
+    {record, ?range_anno('$1', '$2'), any_record_name('$1'), ?val('$2')}.
+record_expr -> expr_callee '#_' '.' record_field_name :
+    {record_field, ?range_anno('$1', '$4'), '$1', any_record_name('$2'), '$4'}.
+record_expr -> expr_callee '#_' record_tuple :
+    {record, ?range_anno('$1', '$3'), '$1', any_record_name('$2'), ?val('$3')}.
 
 macro_record_or_concatable -> var macro_call_none '.' record_field_name :
     Anno = (?range_anno('$1', '$4'))#{macro_record => true},
@@ -1182,6 +1190,9 @@ record_fields([Other | _Fields]) ->
     ret_err(?anno(Other), "bad record field");
 record_fields([]) ->
     [].
+
+any_record_name({'#_', Anno}) ->
+    {var, maps:put(text, "_", Anno), '_'}.
 
 -spec ret_err(_, _) -> no_return().
 ret_err(Anno, S) ->

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -20,7 +20,7 @@ node
 attribute attr_val
 function function_clauses function_clause
 clause_guard clause_body
-expr expr_max expr_max_remote
+expr expr_max expr_callee
 pid dotted_special dotted_seq
 pat_expr pat_expr_max map_pat_expr record_pat_expr
 pat_argument_list pat_exprs
@@ -229,13 +229,13 @@ expr -> expr ':=' expr : {map_field_exact, ?range_anno('$1', '$3'), '$1', '$3'}.
 expr -> prefix_op expr : ?mkop1('$1', '$2').
 expr -> expr '::' type : ?mkop2('$1', '$2', '$3').
 expr -> expr '?=' expr : ?mkop2('$1', '$2', '$3').
-expr -> map_expr : '$1'.
-expr -> function_call : '$1'.
-expr -> record_expr : '$1'.
-expr -> expr_max_remote : '$1'.
+expr -> expr_callee : '$1'.
 
-expr_max_remote -> expr_max ':' expr_max_remote : {remote,?range_anno('$1', '$3'),'$1','$3'}.
-expr_max_remote -> expr_max : '$1'.
+expr_callee -> expr_max ':' expr_callee : {remote,?range_anno('$1', '$3'),'$1','$3'}.
+expr_callee -> function_call : '$1'.
+expr_callee -> record_expr : '$1'.
+expr_callee -> map_expr : '$1'.
+expr_callee -> expr_max : '$1'.
 
 expr_max -> macro_call_expr : '$1'.
 expr_max -> macro_record_or_concatable : '$1'.
@@ -363,9 +363,7 @@ tuple -> '{' exprs '}' : {tuple,?range_anno('$1', '$3'),'$2'}.
 
 map_expr -> '#' map_tuple :
     {map, ?range_anno('$1', '$2'), ?val('$2')}.
-map_expr -> expr_max '#' map_tuple :
-    {map, ?range_anno('$1', '$3'), '$1', ?val('$3')}.
-map_expr -> map_expr '#' map_tuple :
+map_expr -> expr_callee '#' map_tuple :
     {map, ?range_anno('$1', '$3'), '$1', ?val('$3')}.
 
 map_tuple -> '{' '}' : {[], ?anno('$2')}.
@@ -379,13 +377,9 @@ record_expr -> '#' record_name '.' record_field_name :
     {record_index, ?range_anno('$1', '$4'), '$2', '$4'}.
 record_expr -> '#' record_name record_tuple :
     {record, ?range_anno('$1', '$3'), '$2', ?val('$3')}.
-record_expr -> expr_max '#' record_name '.' record_field_name :
+record_expr -> expr_callee '#' record_name '.' record_field_name :
     {record_field, ?range_anno('$1', '$5'), '$1', '$3', '$5'}.
-record_expr -> expr_max '#' record_name record_tuple :
-    {record, ?range_anno('$1', '$4'), '$1', '$3', ?val('$4')}.
-record_expr -> record_expr '#' record_name '.' record_field_name :
-    {record_field, ?range_anno('$1', '$5'), '$1', '$3', '$5'}.
-record_expr -> record_expr '#' record_name record_tuple :
+record_expr -> expr_callee '#' record_name record_tuple :
     {record, ?range_anno('$1', '$4'), '$1', '$3', ?val('$4')}.
 
 macro_record_or_concatable -> var macro_call_none '.' record_field_name :
@@ -410,7 +404,7 @@ record_name -> atom_or_var_or_macro : '$1'.
 
 record_field_name -> atom_or_var_or_macro : '$1'.
 
-function_call -> expr_max_remote argument_list :
+function_call -> expr_callee argument_list :
     {call, ?range_anno('$1', '$2'), '$1', ?val('$2')}.
 
 begin_block -> 'begin' 'end' : {block, ?range_anno('$1', '$2'), []}.

--- a/src/erlfmt_parse.yrl
+++ b/src/erlfmt_parse.yrl
@@ -337,11 +337,15 @@ dotted_seq -> integer '.' dotted_seq : ['$1' | '$3'].
 dotted_seq -> float '.' dotted_seq : ['$1' | '$3'].
 
 list_comprehension -> '[' expr '||' lc_exprs ']' :
-    {lc, ?range_anno('$1', '$5'), '$2', '$4'}.
+    {lc, ?range_anno('$1', '$5'), ['$2'], '$4'}.
+list_comprehension -> '[' expr ',' exprs '||' lc_exprs ']' :
+    {lc, ?range_anno('$1', '$7'), ['$2' | '$4'], '$6'}.
 map_comprehension -> '#' '{' expr '||' lc_exprs '}' :
-    {mc, ?range_anno('$1', '$6'), '$3', '$5'}.
+    {mc, ?range_anno('$1', '$6'), ['$3'], '$5'}.
+map_comprehension -> '#' '{' expr ',' exprs '||' lc_exprs '}' :
+    {mc, ?range_anno('$1', '$8'), ['$3' | '$5'], '$7'}.
 binary_comprehension -> '<<' expr_max '||' lc_exprs '>>' :
-    {bc, ?range_anno('$1', '$5'), '$2', '$4'}.
+    {bc, ?range_anno('$1', '$5'), ['$2'], '$4'}.
 
 lc_exprs -> lc_expr : ['$1'].
 lc_exprs -> lc_expr ',' : ['$1'].

--- a/src/erlfmt_recomment.erl
+++ b/src/erlfmt_recomment.erl
@@ -172,12 +172,12 @@ insert_nested({record, Meta, Expr0, Name, Values0}, Comments0) ->
     {Expr, Comments1} = insert_expr(Expr0, Comments0),
     Values = insert_expr_container(Values0, Comments1),
     {{record, Meta, Expr, Name, Values}, []};
-insert_nested({Comprehension, Meta, Expr0, LcExprs0}, Comments0) when
+insert_nested({Comprehension, Meta, Exprs0, LcExprs0}, Comments0) when
     Comprehension =:= lc; Comprehension =:= bc; Comprehension =:= mc
 ->
-    {Expr, Comments1} = insert_expr(Expr0, Comments0),
+    {Exprs, Comments1} = insert_expr_list(Exprs0, Comments0),
     LcExprs = insert_expr_container(LcExprs0, Comments1),
-    {{Comprehension, Meta, Expr, LcExprs}, []};
+    {{Comprehension, Meta, Exprs, LcExprs}, []};
 insert_nested({Field, Meta, Key0, Value0}, Comments0) when
     Field =:= map_field_assoc;
     Field =:= map_field_exact;

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -108,7 +108,8 @@
     overlong_warning/1,
     do_not_crash_on_bad_record/1,
     raw_string_anno/1,
-    left_assoc_call/1
+    left_assoc_call/1,
+    multi_value_comprehension/1
 ]).
 
 suite() ->
@@ -161,7 +162,8 @@ groups() ->
             raw_string_anno,
             dotted,
             map_comprehension,
-            left_assoc_call
+            left_assoc_call,
+            multi_value_comprehension
         ]},
         {snapshot_tests, [parallel], [
             snapshot_simple_comments,
@@ -1017,7 +1019,7 @@ dotted(Config) when is_list(Config) ->
 
 map_comprehension(Config) when is_list(Config) ->
     ?assertMatch(
-        {mc, _, {map_field_assoc, _, {var, _, 'A'}, {var, _, 'B'}}, [
+        {mc, _, [{map_field_assoc, _, {var, _, 'A'}, {var, _, 'B'}}], [
             {generate, _, '<-', {map_field_exact, _, {var, _, 'A'}, {var, _, 'B'}}, {var, _, 'M'}}
         ]},
         parse_expr("#{A => B || A := B <- M}")
@@ -1845,4 +1847,18 @@ left_assoc_call(Config) when is_list(Config) ->
             {var, _, 'Y'}
         ]},
         parse_expr("Mod:f(X)(Y)")
+    ).
+
+multi_value_comprehension(Config) when is_list(Config) ->
+    ?assertMatch(
+        {lc, _, [{var, _, 'I'}, {op, _, '-', {var, _, 'I'}}], _},
+        parse_expr("[I, -I || I <- List]")
+    ),
+    ?assertMatch(
+        {lc, _, [{var, _, 'X'}], _},
+        parse_expr("[X || X <- List]")
+    ),
+    ?assertMatch(
+        {mc, _, [{var, _, 'A'}, {var, _, 'B'}], _},
+        parse_expr("#{A, B || X <- List}")
     ).

--- a/test/erlfmt_SUITE.erl
+++ b/test/erlfmt_SUITE.erl
@@ -107,7 +107,8 @@
     skip_pragma_escript/1,
     overlong_warning/1,
     do_not_crash_on_bad_record/1,
-    raw_string_anno/1
+    raw_string_anno/1,
+    left_assoc_call/1
 ]).
 
 suite() ->
@@ -159,7 +160,8 @@ groups() ->
             do_not_crash_on_bad_record,
             raw_string_anno,
             dotted,
-            map_comprehension
+            map_comprehension,
+            left_assoc_call
         ]},
         {snapshot_tests, [parallel], [
             snapshot_simple_comments,
@@ -1826,3 +1828,21 @@ raw_string_anno(Config) when is_list(Config) ->
 unicode_string() ->
     "% Overlong, in bytes: "
     "色は匂へど 散りぬるを 我が世誰ぞ 常ならむ 有為の奥山 今日越えて 浅き夢見じ 酔ひもせず\n".
+
+left_assoc_call(Config) when is_list(Config) ->
+    ?assertMatch(
+        {call, _, {call, _, {atom, _, f}, [{var, _, 'X'}]}, [{var, _, 'Y'}]},
+        parse_expr("f(X)(Y)")
+    ),
+    ?assertMatch(
+        {call, _, {call, _, {call, _, {atom, _, f}, [{var, _, 'X'}]}, [{var, _, 'Y'}]}, [
+            {var, _, 'Z'}
+        ]},
+        parse_expr("f(X)(Y)(Z)")
+    ),
+    ?assertMatch(
+        {call, _, {call, _, {remote, _, {var, _, 'Mod'}, {atom, _, f}}, [{var, _, 'X'}]}, [
+            {var, _, 'Y'}
+        ]},
+        parse_expr("Mod:f(X)(Y)")
+    ).

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -48,6 +48,7 @@
     list_comprehension/1,
     map_comprehension/1,
     binary_comprehension/1,
+    multi_value_comprehension/1,
     call/1,
     left_assoc_call/1,
     block/1,
@@ -179,7 +180,8 @@ groups() ->
         {comprehensions, [parallel], [
             list_comprehension,
             map_comprehension,
-            binary_comprehension
+            binary_comprehension,
+            multi_value_comprehension
         ]},
         {otp_27_features, [parallel], [
             sigils,
@@ -2305,6 +2307,28 @@ binary_comprehension(Config) when is_list(Config) ->
         ">>)\n"
     ),
     ?assertFormat("<<A || <<A>> <= Bin,>>\n", "<<A || <<A>> <= Bin>>\n").
+
+multi_value_comprehension(Config) when is_list(Config) ->
+    ?assertSame("[I, -I || I <- lists:seq(1, 5)]\n"),
+    ?assertSame("[K, V || K := V <- Map]\n"),
+    ?assertSame("[A, B, C || A <- As]\n"),
+    ?assertSame("#{K => V, K2 => V2 || K <- List}\n"),
+    ?assertFormat(
+        "[VeryLongExpr, AnotherExpr || X <- List]",
+        "[\n"
+        "    VeryLongExpr,\n"
+        "    AnotherExpr\n"
+        " || X <- List\n"
+        "]\n",
+        25
+    ),
+    %% Expressions should stay grouped when the comprehension is broken
+    ?assertSame(
+        "[\n"
+        "    expr(Var), expr2(Var)\n"
+        " || Var <- List\n"
+        "]\n"
+    ).
 
 call(Config) when is_list(Config) ->
     ?assertFormat("foo(\n)", "foo()\n"),

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -82,7 +82,8 @@
     zip_generators/1,
     nominal_type/1,
     native_record_decl/1,
-    export_import_record/1
+    export_import_record/1,
+    native_record_external/1
 ]).
 
 suite() ->
@@ -201,7 +202,8 @@ groups() ->
         ]},
         {otp_29_features, [parallel], [
             native_record_decl,
-            export_import_record
+            export_import_record,
+            native_record_external
         ]}
     ].
 
@@ -4606,3 +4608,19 @@ native_record_decl(Config) when is_list(Config) ->
 export_import_record(Config) when is_list(Config) ->
     ?assertSame("-export_record([a, b, c]).\n"),
     ?assertSame("-import_record(mod, [a, b]).\n").
+
+native_record_external(Config) when is_list(Config) ->
+    %% Creation
+    ?assertSame("#mod:name{x = 1}\n"),
+    ?assertSame("#?MODULE:name{x = 1}\n"),
+    %% Field access
+    ?assertSame("R#mod:name.field\n"),
+    ?assertSame("R#?MODULE:name.field\n"),
+    %% Update
+    ?assertSame("R#mod:name{field = value}\n"),
+    %% Chained access
+    ?assertSame("R#mod:a.x#mod:b.y\n"),
+    %% In patterns
+    ?assertSame(
+        "f(#mod:name{x = X}) -> X.\n"
+    ).

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -49,6 +49,7 @@
     map_comprehension/1,
     binary_comprehension/1,
     call/1,
+    left_assoc_call/1,
     block/1,
     fun_expression/1,
     case_expression/1,
@@ -128,6 +129,7 @@ groups() ->
             {group, operators},
             {group, comprehensions},
             call,
+            left_assoc_call,
             block,
             fun_expression,
             case_expression,
@@ -2409,6 +2411,31 @@ call(Config) when is_list(Config) ->
         ")\n"
     ),
     ?assertFormat("foo(1,)\n", "foo(1)\n").
+
+left_assoc_call(Config) when is_list(Config) ->
+    ?assertSame("f(X)(Y)\n"),
+    ?assertSame("f(X)(Y)(Z)\n"),
+    ?assertSame("Mod:f(X)(Y)\n"),
+    %% Parens must be preserved for backwards compat with OTP < 29
+    ?assertSame("(f(X))(Y)\n"),
+    ?assertFormat(
+        "f(LongArg1, LongArg2)(ShortA, ShortB)",
+        "f(LongArg1, LongArg2)(\n"
+        "    ShortA, ShortB\n"
+        ")\n",
+        25
+    ),
+    ?assertFormat(
+        "f(X)(LongArg1, LongArg2)",
+        "f(X)(\n"
+        "    LongArg1,\n"
+        "    LongArg2\n"
+        ")\n",
+        20
+    ),
+    %% Calls on record field access
+    ?assertSame("R#foo.bar(X)\n"),
+    ?assertSame("R#foo.bar(X)(Y)\n").
 
 block(Config) when is_list(Config) ->
     ?assertFormat(

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -83,7 +83,8 @@
     nominal_type/1,
     native_record_decl/1,
     export_import_record/1,
-    native_record_external/1
+    native_record_external/1,
+    native_record_any/1
 ]).
 
 suite() ->
@@ -203,7 +204,8 @@ groups() ->
         {otp_29_features, [parallel], [
             native_record_decl,
             export_import_record,
-            native_record_external
+            native_record_external,
+            native_record_any
         ]}
     ].
 
@@ -4623,4 +4625,13 @@ native_record_external(Config) when is_list(Config) ->
     %% In patterns
     ?assertSame(
         "f(#mod:name{x = X}) -> X.\n"
+    ).
+
+native_record_any(Config) when is_list(Config) ->
+    ?assertSame("#_{x = 1, y = 2}\n"),
+    ?assertSame("R#_.field\n"),
+    ?assertSame("R#_{x = 1}\n"),
+    %% In patterns
+    ?assertSame(
+        "f(#_{x = X}) -> X.\n"
     ).

--- a/test/erlfmt_format_SUITE.erl
+++ b/test/erlfmt_format_SUITE.erl
@@ -80,7 +80,9 @@
     maybe_incomplete/1,
     strict_generators/1,
     zip_generators/1,
-    nominal_type/1
+    nominal_type/1,
+    native_record_decl/1,
+    export_import_record/1
 ]).
 
 suite() ->
@@ -102,6 +104,11 @@ init_per_group(otp_28_features, Config) ->
     case erlang:system_info(otp_release) >= "28" of
         true -> Config;
         false -> {skip, "Skipping tests for features from OTP >= 28"}
+    end;
+init_per_group(otp_29_features, Config) ->
+    case erlang:system_info(otp_release) >= "29" of
+        true -> Config;
+        false -> {skip, "Skipping tests for features from OTP >= 29"}
     end;
 init_per_group(_GroupName, Config) ->
     Config.
@@ -191,6 +198,10 @@ groups() ->
             strict_generators,
             zip_generators,
             nominal_type
+        ]},
+        {otp_29_features, [parallel], [
+            native_record_decl,
+            export_import_record
         ]}
     ].
 
@@ -200,6 +211,7 @@ all() ->
         {group, forms},
         {group, otp_27_features},
         {group, otp_28_features},
+        {group, otp_29_features},
         comment
     ].
 
@@ -4578,3 +4590,19 @@ nominal_type(Config) when is_list(Config) ->
     ?assertSame(
         "-nominal foo() :: {fun(), fun((...) -> mod:bar()), fun(() -> integer())}.\n"
     ).
+
+native_record_decl(Config) when is_list(Config) ->
+    ?assertSame("-record #empty{}.\n"),
+    ?assertSame("-record #a{x, y}.\n"),
+    ?assertSame("-record #c{x :: integer(), y = 0 :: integer()}.\n"),
+    ?assertSame(
+        "-record #d{\n"
+        "    f = 3.1416,\n"
+        "    l = [a, b, c]\n"
+        "}.\n"
+    ),
+    ?assertSame("-record #point{x = 0, y = 0, z = 0}.\n").
+
+export_import_record(Config) when is_list(Config) ->
+    ?assertSame("-export_record([a, b, c]).\n"),
+    ?assertSame("-import_record(mod, [a, b]).\n").


### PR DESCRIPTION
* left-associative function application
* multi-valued comprehensions (EEP 78)
* native records (EEP 79)
* CI for OTP 29

This should be merged & released once the final release is ready